### PR TITLE
feat: allow to build for multiarch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,33 @@
-FROM rust:1.61 as builder
-RUN rustup target add x86_64-unknown-linux-musl
-RUN apt-get update && apt-get install --no-install-recommends -y musl-tools
-WORKDIR /app
-COPY . .
-RUN cargo build --target x86_64-unknown-linux-musl --release
+FROM --platform=$BUILDPLATFORM rust:1.61-alpine AS vendor
 
-FROM scratch
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/dufs /bin/
+ENV USER=root
+
+WORKDIR /app
+RUN cargo init
+COPY Cargo.toml /app/Cargo.toml
+COPY Cargo.lock /app/Cargo.lock
+RUN mkdir -p /app/.cargo \
+  && cargo vendor > /app/.cargo/config
+  
+FROM rust:1.61-alpine AS builder
+
+RUN apk add ca-certificates openssl-dev openssl musl-dev
+
+ENV USER=root
+
+WORKDIR /app
+
+COPY Cargo.toml /app/Cargo.toml
+COPY Cargo.lock /app/Cargo.lock
+COPY src /app/src
+COPY assets /app/assets
+COPY --from=vendor /app/.cargo /app/.cargo
+COPY --from=vendor /app/vendor /app/vendor
+
+RUN cargo build --release --offline
+
+FROM gcr.io/distroless/static
+
+COPY --from=builder /app/target/release/dufs /bin/
+
 ENTRYPOINT ["/bin/dufs"]


### PR DESCRIPTION
This removes the dependence on the architecture in the dockerfile.
There is now a new step to fetch the dependencies before doing the
build to mutualize dependency fetching when building multi arch images.

it's now possible to build for multiple architecture using

```
docker buildx build --platform linux/amd64,linux/arm64 ...
```

Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>