### PR TITLE
Add support for nix using flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,74 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1655042882,
+        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1656338871,
+        "narHash": "sha256-+LOvZFt3MpWtrxXLH4igQtRVzyD43VnuTJjDVbt7phY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "819e4d63fc7f337a822a049fd055cd7615a5e0d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1656338871,
+        "narHash": "sha256-+LOvZFt3MpWtrxXLH4igQtRVzyD43VnuTJjDVbt7phY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "819e4d63fc7f337a822a049fd055cd7615a5e0d6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  inputs = {
+    utils.url = "github:numtide/flake-utils";
+    naersk.url = "github:nix-community/naersk";
+  };
+
+  outputs = { self, nixpkgs, utils, naersk }:
+    utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages."${system}";
+      naersk-lib = naersk.lib."${system}";
+    in rec {
+      # `nix build`
+      packages.dufs = naersk-lib.buildPackage {
+        pname = "dufs";
+        root = ./.;
+      };
+      defaultPackage = packages.dufs;
+
+      # `nix run`
+      apps.default = utils.lib.mkApp { drv = packages.dufs;};
+
+      # `nix develop`
+      devShell = pkgs.mkShell {
+        nativeBuildInputs = with pkgs; [ rustc cargo ];
+      };
+    });
+}


### PR DESCRIPTION
Added support for using [Nix](https://github.com/NixOS/nix) package manager to build & run the repo.

Several usage examples:

```bash

$ nix run . -- --help
dufs 0.22.0
sigoden <sigoden@gmail.com>
...

$ nix build && ./result/bin/dufs --help
dufs 0.22.0
sigoden <sigoden@gmail.com>
...

$ nix develop # creates a shell with cargo & rustc
$ cargo run -- --help
    Updating crates.io index
```

