### PR TITLE
feat: improve hidden to support glob

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -159,7 +159,7 @@ pub struct Args {
     pub path_is_file: bool,
     pub path_prefix: String,
     pub uri_prefix: String,
-    pub hidden: String,
+    pub hidden: Vec<String>,
     pub auth_method: AuthMethod,
     pub auth: AccessControl,
     pub allow_upload: bool,
@@ -199,9 +199,9 @@ impl Args {
         } else {
             format!("/{}/", &encode_uri(&path_prefix))
         };
-        let hidden: String = matches
+        let hidden: Vec<String> = matches
             .value_of("hidden")
-            .map(|v| format!(",{},", v))
+            .map(|v| v.split(',').map(|x| x.to_string()).collect())
             .unwrap_or_default();
         let enable_cors = matches.is_present("enable-cors");
         let auth: Vec<&str> = matches

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,3 +23,61 @@ pub fn try_get_file_name(path: &Path) -> BoxResult<&str> {
         .and_then(|v| v.to_str())
         .ok_or_else(|| format!("Failed to get file name of `{}`", path.display()).into())
 }
+
+pub fn glob(source: &str, target: &str) -> bool {
+    let ss: Vec<char> = source.chars().collect();
+    let mut iter = target.chars();
+    let mut i = 0;
+    'outer: while i < ss.len() {
+        let s = ss[i];
+        match s {
+            '*' => match ss.get(i + 1) {
+                Some(s_next) => {
+                    for t in iter.by_ref() {
+                        if t == *s_next {
+                            i += 2;
+                            continue 'outer;
+                        }
+                    }
+                    return true;
+                }
+                None => return true,
+            },
+            '?' => match iter.next() {
+                Some(_) => {
+                    i += 1;
+                    continue;
+                }
+                None => return false,
+            },
+            _ => match iter.next() {
+                Some(t) => {
+                    if s == t {
+                        i += 1;
+                        continue;
+                    }
+                    return false;
+                }
+                None => return false,
+            },
+        }
+    }
+    iter.next().is_none()
+}
+
+#[test]
+fn test_glob_key() {
+    assert!(glob("", ""));
+    assert!(glob(".*", ".git"));
+    assert!(glob("abc", "abc"));
+    assert!(glob("a*c", "abc"));
+    assert!(glob("a?c", "abc"));
+    assert!(glob("a*c", "abbc"));
+    assert!(glob("*c", "abc"));
+    assert!(glob("a*", "abc"));
+    assert!(glob("?c", "bc"));
+    assert!(glob("a?", "ab"));
+    assert!(!glob("abc", "adc"));
+    assert!(!glob("abc", "abcd"));
+    assert!(!glob("a?c", "abbc"));
+}


### PR DESCRIPTION
With thi pr merged, dufs allows pass glob to --hidden.

For example `dufs --hidden '.*'` will wroks. close #107 

Note:  the glob is not followd Standard Unix-style. only `?` and `*` is supported.