### PR TITLE
feat: support customize http log format

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,23 +191,21 @@ dufs -a /@admin:pass1@* -a /ui@designer:pass2 -A
 
 ## Log format
 
-dufs supports custom http log format via option `--log-format`.
+dufs supports customize http log format via option `--log-format`.
 
-The default format is `$remote_addr "$request" $status $error`.
+The default format is `$remote_addr "$request" $status`.
 
 All variables list below:
 
-| name                  | description                            |
-| --------------------- | -------------------------------------- |
-| $remote_addr          | client address                         |
-| $remote_user          | user name supplied with authentication |
-| $request              | full original request line             |
-| $status               | response status                        |
-| $error                | internal error                         |
-| $http_referer         | refer header                           |
-| $http_user_agent      | user-agent header                      |
-| $http_x_forwarded_for | x-forwarded-for header                 |
+| name         | description                                                               |
+| ------------ | ------------------------------------------------------------------------- |
+| $remote_addr | client address                                                            |
+| $remote_user | user name supplied with authentication                                    |
+| $request     | full original request line                                                |
+| $status      | response status                                                           |
+| $http_       | arbitrary request header field. examples: $http_user_agent, $http_referer |
 
+> use `dufs --log-format=''` to disable http log
 ## License
 
 Copyright (c) 2022 dufs-developers.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ OPTIONS:
         --render-index           Serve index.html when requesting a directory, returns 404 if not found index.html
         --render-try-index       Serve index.html when requesting a directory, returns directory listing if not found index.html
         --render-spa             Serve SPA(Single Page Application)
-        --completions <shell>    Print shell completion script for <shell> [possible values: bash, elvish, fish, powershell, zsh]
         --tls-cert <path>        Path to an SSL/TLS certificate to serve with HTTPS
         --tls-key <path>         Path to the SSL/TLS certificate's private key
+        --no-log                 Don't log http information
+        --log-format <format>    Customize http log format
+        --completions <shell>    Print shell completion script for <shell> [possible values: bash, elvish, fish, powershell, zsh]
     -h, --help                   Print help information
     -V, --version                Print version information
 ```
@@ -186,6 +188,25 @@ dufs -a /@admin:pass1@* -a /ui@designer:pass2 -A
 - All files/folders are public to view/download.
 - Account `admin:pass1` can upload/delete/view/download any files/folders.
 - Account `designer:pass2` can upload/delete/view/download any files/folders in the `ui` folder.
+
+## Log format
+
+dufs supports custom http log format via option `--log-format`.
+
+The default format is `$remote_addr "$request" $status $error`.
+
+All variables list below:
+
+| name                  | description                            |
+| --------------------- | -------------------------------------- |
+| $remote_addr          | client address                         |
+| $remote_user          | user name supplied with authentication |
+| $request              | full original request line             |
+| $status               | response status                        |
+| $error                | internal error                         |
+| $http_referer         | refer header                           |
+| $http_user_agent      | user-agent header                      |
+| $http_x_forwarded_for | x-forwarded-for header                 |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ OPTIONS:
         --render-spa             Serve SPA(Single Page Application)
         --tls-cert <path>        Path to an SSL/TLS certificate to serve with HTTPS
         --tls-key <path>         Path to the SSL/TLS certificate's private key
-        --no-log                 Don't log http information
         --log-format <format>    Customize http log format
         --completions <shell>    Print shell completion script for <shell> [possible values: bash, elvish, fish, powershell, zsh]
     -h, --help                   Print help information

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::auth::AccessControl;
 use crate::auth::AuthMethod;
+use crate::log_http::{LogHttp, DEFAULT_LOG_FORMAT};
 #[cfg(feature = "tls")]
 use crate::tls::{load_certs, load_private_key};
 use crate::utils::encode_uri;
@@ -180,6 +181,7 @@ pub struct Args {
     pub render_spa: bool,
     pub render_try_index: bool,
     pub enable_cors: bool,
+    pub log_http: LogHttp,
     #[cfg(feature = "tls")]
     pub tls: Option<(Vec<Certificate>, PrivateKey)>,
     #[cfg(not(feature = "tls"))]
@@ -241,6 +243,10 @@ impl Args {
         };
         #[cfg(not(feature = "tls"))]
         let tls = None;
+        let log_http: LogHttp = matches
+            .value_of("log-format")
+            .unwrap_or(DEFAULT_LOG_FORMAT)
+            .parse()?;
 
         Ok(Args {
             addrs,
@@ -261,6 +267,7 @@ impl Args {
             render_try_index,
             render_spa,
             tls,
+            log_http,
         })
     }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -139,11 +139,6 @@ pub fn build_cli() -> Command<'static> {
         );
 
     app.arg(
-        Arg::new("no-log")
-            .long("no-log")
-            .help("Don't log http information"),
-    )
-    .arg(
         Arg::new("log-format")
             .long("log-format")
             .value_name("format")

--- a/src/args.rs
+++ b/src/args.rs
@@ -120,13 +120,6 @@ pub fn build_cli() -> Command<'static> {
             Arg::new("render-spa")
                 .long("render-spa")
                 .help("Serve SPA(Single Page Application)"),
-        )
-        .arg(
-            Arg::new("completions")
-                .long("completions")
-                .value_name("shell")
-                .value_parser(value_parser!(Shell))
-                .help("Print shell completion script for <shell>"),
         );
 
     #[cfg(feature = "tls")]
@@ -144,7 +137,24 @@ pub fn build_cli() -> Command<'static> {
                 .help("Path to the SSL/TLS certificate's private key"),
         );
 
-    app
+    app.arg(
+        Arg::new("no-log")
+            .long("no-log")
+            .help("Don't log http information"),
+    )
+    .arg(
+        Arg::new("log-format")
+            .long("log-format")
+            .value_name("format")
+            .help("Customize http log format"),
+    )
+    .arg(
+        Arg::new("completions")
+            .long("completions")
+            .value_name("shell")
+            .value_parser(value_parser!(Shell))
+            .help("Print shell completion script for <shell>"),
+    )
 }
 
 pub fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {

--- a/src/log_http.rs
+++ b/src/log_http.rs
@@ -1,0 +1,99 @@
+use std::{collections::HashMap, str::FromStr, sync::Arc};
+
+use crate::{args::Args, server::Request};
+
+pub const DEFAULT_LOG_FORMAT: &str = r#"$remote_addr "$request" $status"#;
+
+#[derive(Debug)]
+pub struct LogHttp {
+    elems: Vec<LogElement>,
+}
+
+#[derive(Debug)]
+enum LogElement {
+    Variable(String),
+    Header(String),
+    Literal(String),
+}
+
+impl LogHttp {
+    pub fn data(&self, req: &Request, args: &Arc<Args>) -> HashMap<String, String> {
+        let mut data = HashMap::default();
+        for elem in self.elems.iter() {
+            match elem {
+                LogElement::Variable(name) => match name.as_str() {
+                    "request" => {
+                        data.insert(name.to_string(), format!("{} {}", req.method(), req.uri()));
+                    }
+                    "remote_user" => {
+                        if let Some(user) = req
+                            .headers()
+                            .get("authorization")
+                            .and_then(|v| args.auth_method.get_user(v))
+                        {
+                            data.insert(name.to_string(), user);
+                        }
+                    }
+                    _ => {}
+                },
+                LogElement::Header(name) => {
+                    if let Some(value) = req.headers().get(name).and_then(|v| v.to_str().ok()) {
+                        data.insert(name.to_string(), value.to_string());
+                    }
+                }
+                LogElement::Literal(_) => {}
+            }
+        }
+        data
+    }
+    pub fn log(&self, data: &HashMap<String, String>, err: Option<String>) {
+        if self.elems.is_empty() {
+            return;
+        }
+        let mut output = String::new();
+        for elem in self.elems.iter() {
+            match elem {
+                LogElement::Literal(value) => output.push_str(value.as_str()),
+                LogElement::Header(name) | LogElement::Variable(name) => {
+                    output.push_str(data.get(name).map(|v| v.as_str()).unwrap_or("-"))
+                }
+            }
+        }
+        match err {
+            Some(err) => error!("{} {}", output, err),
+            None => info!("{}", output),
+        }
+    }
+}
+
+impl FromStr for LogHttp {
+    type Err = Box<dyn std::error::Error>;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut elems = vec![];
+        let mut is_var = false;
+        let mut cache = String::new();
+        for c in format!("{} ", s).chars() {
+            if c == '$' {
+                if !cache.is_empty() {
+                    elems.push(LogElement::Literal(cache.to_string()));
+                }
+                cache.clear();
+                is_var = true;
+            } else if is_var && !(c.is_alphanumeric() || c == '_') {
+                if let Some(value) = cache.strip_prefix("$http_") {
+                    elems.push(LogElement::Header(value.replace('_', "-").to_string()));
+                } else if let Some(value) = cache.strip_prefix('$') {
+                    elems.push(LogElement::Variable(value.to_string()));
+                }
+                cache.clear();
+                is_var = false;
+            }
+            cache.push(c);
+        }
+        let cache = cache.trim();
+        if !cache.is_empty() {
+            elems.push(LogElement::Literal(cache.to_string()));
+        }
+        Ok(Self { elems })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod args;
 mod auth;
+mod log_http;
 mod logger;
 mod server;
 mod streamer;

--- a/tests/log_http.rs
+++ b/tests/log_http.rs
@@ -1,0 +1,78 @@
+mod fixtures;
+mod utils;
+
+use diqwest::blocking::WithDigestAuth;
+use fixtures::{port, tmpdir, wait_for_port, Error};
+
+use assert_cmd::prelude::*;
+use assert_fs::fixture::TempDir;
+use rstest::rstest;
+use std::io::Read;
+use std::process::{Command, Stdio};
+
+#[rstest]
+#[case(&["-a", "/@user:pass", "--log-format", "$remote_user"], false)]
+#[case(&["-a", "/@user:pass", "--log-format", "$remote_user", "--auth-method", "basic"], true)]
+fn log_remote_user(
+    tmpdir: TempDir,
+    port: u16,
+    #[case] args: &[&str],
+    #[case] is_basic: bool,
+) -> Result<(), Error> {
+    let mut child = Command::cargo_bin("dufs")?
+        .arg(tmpdir.path())
+        .arg("-p")
+        .arg(port.to_string())
+        .args(args)
+        .stdout(Stdio::piped())
+        .spawn()?;
+
+    wait_for_port(port);
+
+    let stdout = child.stdout.as_mut().expect("Failed to get stdout");
+
+    let req = fetch!(b"GET", &format!("http://localhost:{}", port));
+
+    let resp = if is_basic {
+        req.basic_auth("user", Some("pass")).send()?
+    } else {
+        req.send_with_digest_auth("user", "pass")?
+    };
+
+    assert_eq!(resp.status(), 200);
+
+    let mut buf = [0; 1000];
+    let buf_len = stdout.read(&mut buf)?;
+    let output = std::str::from_utf8(&buf[0..buf_len])?;
+
+    assert!(output.lines().last().unwrap().ends_with("user"));
+
+    child.kill()?;
+    Ok(())
+}
+
+#[rstest]
+#[case(&["--log-format"])]
+fn no_log(tmpdir: TempDir, port: u16, #[case] args: &[&str]) -> Result<(), Error> {
+    let mut child = Command::cargo_bin("dufs")?
+        .arg(tmpdir.path())
+        .arg("-p")
+        .arg(port.to_string())
+        .args(args)
+        .stdout(Stdio::piped())
+        .spawn()?;
+
+    wait_for_port(port);
+
+    let stdout = child.stdout.as_mut().expect("Failed to get stdout");
+
+    let resp = fetch!(b"GET", &format!("http://localhost:{}", port)).send()?;
+    assert_eq!(resp.status(), 200);
+
+    let mut buf = [0; 1000];
+    let buf_len = stdout.read(&mut buf)?;
+    let output = std::str::from_utf8(&buf[0..buf_len])?;
+
+    assert_eq!(output.lines().last().unwrap(), "");
+    Ok(())
+}

--- a/tests/log_http.rs
+++ b/tests/log_http.rs
@@ -52,7 +52,7 @@ fn log_remote_user(
 }
 
 #[rstest]
-#[case(&["--log-format"])]
+#[case(&["--log-format", ""])]
 fn no_log(tmpdir: TempDir, port: u16, #[case] args: &[&str]) -> Result<(), Error> {
     let mut child = Command::cargo_bin("dufs")?
         .arg(tmpdir.path())


### PR DESCRIPTION
dufs supports customize http log format via option `--log-format`.

The default format is `$remote_addr "$request" $status`.

All variables list below:

| name         | description                                                               |
| ------------ | ------------------------------------------------------------------------- |
| $remote_addr | client address                                                            |
| $remote_user | user name supplied with authentication                                    |
| $request     | full original request line                                                |
| $status      | response status                                                           |
| $http_       | arbitrary request header field. examples: $http_user_agent, $http_referer |

> use `dufs --log-format=''` to disable http log