### PR TITLE
fix: table row hover highlighting in dark mode

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -231,4 +231,8 @@ body {
   .path a {
     color: #3191ff;
   }
+
+  .paths-table tr:hover {
+    background-color: #1a1a1a;
+  }
 } 


### PR DESCRIPTION
close #121 