### PR TITLE
fix: don't search on empty query string

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -37,7 +37,7 @@
       <div class="icon">
         <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/></svg>
       </div>
-      <input id="search" name="q" type="text" maxlength="128" autocomplete="off" tabindex="1">
+      <input id="search" name="q" type="text" maxlength="128" autocomplete="off" tabindex="1" required>
       <input type="submit" hidden />
     </form>
   </div>

--- a/src/server.rs
+++ b/src/server.rs
@@ -195,7 +195,7 @@ impl Server {
                     if render_try_index {
                         if query_params.contains_key("zip") {
                             self.handle_zip_dir(path, head_only, &mut res).await?;
-                        } else if allow_search && query_params.contains_key("q") {
+                        } else if allow_search && query_params.contains_key("q") && !query_params.get("q").unwrap().is_empty() {
                             self.handle_search_dir(path, &query_params, head_only, &mut res)
                                 .await?;
                         } else {
@@ -213,7 +213,7 @@ impl Server {
                             .await?;
                     } else if query_params.contains_key("zip") {
                         self.handle_zip_dir(path, head_only, &mut res).await?;
-                    } else if allow_search && query_params.contains_key("q") {
+                    } else if allow_search && query_params.contains_key("q") && !query_params.get("q").unwrap().is_empty() {
                         self.handle_search_dir(path, &query_params, head_only, &mut res)
                             .await?;
                     } else {

--- a/src/server.rs
+++ b/src/server.rs
@@ -195,7 +195,7 @@ impl Server {
                     if render_try_index {
                         if query_params.contains_key("zip") {
                             self.handle_zip_dir(path, head_only, &mut res).await?;
-                        } else if allow_search && query_params.contains_key("q") && !query_params.get("q").unwrap().is_empty() {
+                        } else if allow_search && query_params.contains_key("q") {
                             self.handle_search_dir(path, &query_params, head_only, &mut res)
                                 .await?;
                         } else {
@@ -213,7 +213,7 @@ impl Server {
                             .await?;
                     } else if query_params.contains_key("zip") {
                         self.handle_zip_dir(path, head_only, &mut res).await?;
-                    } else if allow_search && query_params.contains_key("q") && !query_params.get("q").unwrap().is_empty() {
+                    } else if allow_search && query_params.contains_key("q") {
                         self.handle_search_dir(path, &query_params, head_only, &mut res)
                             .await?;
                     } else {
@@ -386,41 +386,43 @@ impl Server {
         res: &mut Response,
     ) -> BoxResult<()> {
         let mut paths: Vec<PathItem> = vec![];
-        let path_buf = path.to_path_buf();
-        let hidden = Arc::new(self.args.hidden.to_vec());
-        let hidden = hidden.clone();
-        let running = self.running.clone();
         let search = query_params.get("q").unwrap().to_lowercase();
-        let search_paths = tokio::task::spawn_blocking(move || {
-            let mut it = WalkDir::new(&path_buf).into_iter();
-            let mut paths: Vec<PathBuf> = vec![];
-            while let Some(Ok(entry)) = it.next() {
-                if !running.load(Ordering::SeqCst) {
-                    break;
-                }
-                let entry_path = entry.path();
-                let base_name = get_file_name(entry_path);
-                let file_type = entry.file_type();
-                if is_hidden(&hidden, base_name) {
-                    if file_type.is_dir() {
-                        it.skip_current_dir();
+        if !search.is_empty() {
+            let path_buf = path.to_path_buf();
+            let hidden = Arc::new(self.args.hidden.to_vec());
+            let hidden = hidden.clone();
+            let running = self.running.clone();
+            let search_paths = tokio::task::spawn_blocking(move || {
+                let mut it = WalkDir::new(&path_buf).into_iter();
+                let mut paths: Vec<PathBuf> = vec![];
+                while let Some(Ok(entry)) = it.next() {
+                    if !running.load(Ordering::SeqCst) {
+                        break;
                     }
-                    continue;
+                    let entry_path = entry.path();
+                    let base_name = get_file_name(entry_path);
+                    let file_type = entry.file_type();
+                    if is_hidden(&hidden, base_name) {
+                        if file_type.is_dir() {
+                            it.skip_current_dir();
+                        }
+                        continue;
+                    }
+                    if !base_name.to_lowercase().contains(&search) {
+                        continue;
+                    }
+                    if entry.path().symlink_metadata().is_err() {
+                        continue;
+                    }
+                    paths.push(entry_path.to_path_buf());
                 }
-                if !base_name.to_lowercase().contains(&search) {
-                    continue;
+                paths
+            })
+            .await?;
+            for search_path in search_paths.into_iter() {
+                if let Ok(Some(item)) = self.to_pathitem(search_path, path.to_path_buf()).await {
+                    paths.push(item);
                 }
-                if entry.path().symlink_metadata().is_err() {
-                    continue;
-                }
-                paths.push(entry_path.to_path_buf());
-            }
-            paths
-        })
-        .await?;
-        for search_path in search_paths.into_iter() {
-            if let Ok(Some(item)) = self.to_pathitem(search_path, path.to_path_buf()).await {
-                paths.push(item);
             }
         }
         self.send_index(path, paths, true, query_params, head_only, res)

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -99,6 +99,15 @@ fn head_dir_search(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
 }
 
 #[rstest]
+fn empty_search(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
+    let resp = reqwest::blocking::get(format!("{}?q=", server.url()))?;
+    assert_eq!(resp.status(), 200);
+    let paths = utils::retrieve_index_paths(&resp.text()?);
+    assert!(paths.is_empty());
+    Ok(())
+}
+
+#[rstest]
 fn get_file(server: TestServer) -> Result<(), Error> {
     let resp = reqwest::blocking::get(format!("{}index.html", server.url()))?;
     assert_eq!(resp.status(), 200);


### PR DESCRIPTION
Submitting empty searches was calling handle_search_dir() instead of simply returning the index, returning in a blank line in the results and potentially causing hanging or crashing in large directory trees.
![blankline](https://user-images.githubusercontent.com/13181863/197298718-036c05f8-9f1e-4ca5-91fd-15ef55794399.png)

It may be best to also call .trim() before .is_empty() if it's felt that searching for simply whitespaces should be disabled.