### PR TITLE
Fix status code for MKCOL on existing resource

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -273,7 +273,8 @@ impl Server {
                     if !allow_upload {
                         status_forbid(&mut res);
                     } else if !is_miss {
-                        status_method_not_allowed(&mut res);
+                        *res.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+                        *res.body_mut() = Body::from("Already exists");
                     } else {
                         self.handle_mkcol(path, &mut res).await?;
                     }
@@ -1208,12 +1209,6 @@ fn status_forbid(res: &mut Response) {
 fn status_not_found(res: &mut Response) {
     *res.status_mut() = StatusCode::NOT_FOUND;
     *res.body_mut() = Body::from("Not Found");
-}
-
-fn status_method_not_allowed(res: &mut Response) {
-    *res.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
-    *res.body_mut() = Body::from("Already exists");
-    // TOOD: sent back a valid ALLOW header
 }
 
 fn status_no_content(res: &mut Response) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -270,8 +270,10 @@ impl Server {
                     }
                 }
                 "MKCOL" => {
-                    if !allow_upload || !is_miss {
+                    if !allow_upload {
                         status_forbid(&mut res);
+                    } else if !is_miss {
+                        status_method_not_allowed(&mut res);
                     } else {
                         self.handle_mkcol(path, &mut res).await?;
                     }
@@ -1206,6 +1208,12 @@ fn status_forbid(res: &mut Response) {
 fn status_not_found(res: &mut Response) {
     *res.status_mut() = StatusCode::NOT_FOUND;
     *res.body_mut() = Body::from("Not Found");
+}
+
+fn status_method_not_allowed(res: &mut Response) {
+    *res.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+    *res.body_mut() = Body::from("Already exists");
+    // TOOD: sent back a valid ALLOW header
 }
 
 fn status_no_content(res: &mut Response) {

--- a/tests/webdav.rs
+++ b/tests/webdav.rs
@@ -94,6 +94,13 @@ fn mkcol_not_allow_upload(server: TestServer) -> Result<(), Error> {
 }
 
 #[rstest]
+fn mkcol_already_exists(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
+    let resp = fetch!(b"MKCOL", format!("{}dira", server.url())).send()?;
+    assert_eq!(resp.status(), 405);
+    Ok(())
+}
+
+#[rstest]
 fn copy_file(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
     let new_url = format!("{}test2.html", server.url());
     let resp = fetch!(b"COPY", format!("{}test.html", server.url()))


### PR DESCRIPTION
Per https://datatracker.ietf.org/doc/html/rfc4918#section-9.3.1,
MKCOL should return a 405 if the resource already exists.

Impetus for this change:
I am using dufs as a webdav server for [Joplin](https://joplinapp.org/)
which interpreted the previous behavior of returning a 403 as an error,
preventing syncing from working.