### PR TITLE
docs: fix typos

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    name: Publish to Github Relases
+    name: Publish to Github Releases
     outputs:
       rc: ${{ steps.check-tag.outputs.rc }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- File path contains special charactors ([#114](https://github.com/sigoden/dufs/issues/114))
+- File path contains special characters ([#114](https://github.com/sigoden/dufs/issues/114))
 
 ### Features
 
@@ -65,7 +65,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- Unexpect stack overflow when searching a lot ([#87](https://github.com/sigoden/dufs/issues/87))
+- Unexpected stack overflow when searching a lot ([#87](https://github.com/sigoden/dufs/issues/87))
 
 ### Features
 
@@ -158,7 +158,7 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor
 
-- Trival changes ([#41](https://github.com/sigoden/dufs/issues/41))
+- Trivial changes ([#41](https://github.com/sigoden/dufs/issues/41))
 
 ## [0.16.0] - 2022-06-12
 

--- a/assets/index.js
+++ b/assets/index.js
@@ -498,11 +498,11 @@ function formatDuration(seconds) {
   return `${padZero(h, 2)}:${padZero(m, 2)}:${padZero(s, 2)}`;
 }
 
-function formatPercent(precent) {
-  if (precent > 10) {
-    return precent.toFixed(1) + "%";
+function formatPercent(percent) {
+  if (percent > 10) {
+    return percent.toFixed(1) + "%";
   } else {
-    return precent.toFixed(2) + "%";
+    return percent.toFixed(2) + "%";
   }
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -196,7 +196,7 @@ pub struct Args {
 impl Args {
     /// Parse command-line arguments.
     ///
-    /// If a parsing error ocurred, exit the process and print out informative
+    /// If a parsing error occurred, exit the process and print out informative
     /// error message to user.
     pub fn parse(matches: ArgMatches) -> BoxResult<Args> {
         let port = matches.value_of_t::<u16>("port")?;


### PR DESCRIPTION
Found via `codespell -S target -L crate,nd`