### PR TITLE
feat: hiding only directories instead of files

### DIFF
--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -65,6 +65,7 @@ pub fn tmpdir() -> TempDir {
             }
         }
     }
+    tmpdir.child("dir4/hidden").touch().unwrap();
 
     tmpdir
 }

--- a/tests/hidden.rs
+++ b/tests/hidden.rs
@@ -55,3 +55,18 @@ fn hidden_search_dir(#[case] server: TestServer, #[case] exist: bool) -> Result<
     }
     Ok(())
 }
+
+#[rstest]
+#[case(server(&["--hidden", "hidden/"]), "dir4/", 1)]
+#[case(server(&["--hidden", "hidden"]), "dir4/", 0)]
+fn hidden_dir_noly(
+    #[case] server: TestServer,
+    #[case] dir: &str,
+    #[case] count: usize,
+) -> Result<(), Error> {
+    let resp = reqwest::blocking::get(format!("{}{}", server.url(), dir))?;
+    assert_eq!(resp.status(), 200);
+    let paths = utils::retrieve_index_paths(&resp.text()?);
+    assert_eq!(paths.len(), count);
+    Ok(())
+}


### PR DESCRIPTION
A `--hidden` pattern with `/` suffix means hiding only directories not files.
A `--hidden` pattern without `/` will hide matching files and directories.
close #162 