### PR TITLE
feat: API to search and list directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ Delete a file/folder
 curl -X DELETE http://127.0.0.1:5000/path-to-file-or-folder
 ```
 
+List/search directory contents
+
+```
+curl http://127.0.0.1:5000?simple                 # output pathname only, just like `ls -1`
+
+curl http://127.0.0.1:5000?json                   # output name/mtime/type/size and other information in json format
+
+curl http://127.0.0.1:5000?q=Dockerfile&simple    # search for files, just like `find -name Dockerfile`
+```
+
 <details>
 <summary><h2>Advanced topics</h2></summary>
 

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -11,13 +11,13 @@ use std::process::{Command, Stdio};
 fn assets(server: TestServer) -> Result<(), Error> {
     let ver = env!("CARGO_PKG_VERSION");
     let resp = reqwest::blocking::get(server.url())?;
-    let index_js = format!("/__dufs_v{}_index.js", ver);
-    let index_css = format!("/__dufs_v{}_index.css", ver);
-    let favicon_ico = format!("/__dufs_v{}_favicon.ico", ver);
+    let index_js = format!("/__dufs_v{ver}_index.js");
+    let index_css = format!("/__dufs_v{ver}_index.css");
+    let favicon_ico = format!("/__dufs_v{ver}_favicon.ico");
     let text = resp.text()?;
-    assert!(text.contains(&format!(r#"href="{}""#, index_css)));
-    assert!(text.contains(&format!(r#"href="{}""#, favicon_ico)));
-    assert!(text.contains(&format!(r#"src="{}""#, index_js)));
+    assert!(text.contains(&format!(r#"href="{index_css}""#)));
+    assert!(text.contains(&format!(r#"href="{favicon_ico}""#)));
+    assert!(text.contains(&format!(r#"src="{index_js}""#)));
     Ok(())
 }
 
@@ -67,13 +67,13 @@ fn asset_ico(server: TestServer) -> Result<(), Error> {
 fn assets_with_prefix(#[with(&["--path-prefix", "xyz"])] server: TestServer) -> Result<(), Error> {
     let ver = env!("CARGO_PKG_VERSION");
     let resp = reqwest::blocking::get(format!("{}xyz/", server.url()))?;
-    let index_js = format!("/xyz/__dufs_v{}_index.js", ver);
-    let index_css = format!("/xyz/__dufs_v{}_index.css", ver);
-    let favicon_ico = format!("/xyz/__dufs_v{}_favicon.ico", ver);
+    let index_js = format!("/xyz/__dufs_v{ver}_index.js");
+    let index_css = format!("/xyz/__dufs_v{ver}_index.css");
+    let favicon_ico = format!("/xyz/__dufs_v{ver}_favicon.ico");
     let text = resp.text()?;
-    assert!(text.contains(&format!(r#"href="{}""#, index_css)));
-    assert!(text.contains(&format!(r#"href="{}""#, favicon_ico)));
-    assert!(text.contains(&format!(r#"src="{}""#, index_js)));
+    assert!(text.contains(&format!(r#"href="{index_css}""#)));
+    assert!(text.contains(&format!(r#"href="{favicon_ico}""#)));
+    assert!(text.contains(&format!(r#"src="{index_js}""#)));
     Ok(())
 }
 
@@ -108,7 +108,7 @@ fn assets_override(tmpdir: TempDir, port: u16) -> Result<(), Error> {
 
     wait_for_port(port);
 
-    let url = format!("http://localhost:{}", port);
+    let url = format!("http://localhost:{port}");
     let resp = reqwest::blocking::get(&url)?;
     assert!(resp.text()?.starts_with(&format!(
         "/__dufs_v{}_index.js;DATA",

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -44,7 +44,7 @@ pub fn tmpdir() -> TempDir {
     for file in FILES {
         tmpdir
             .child(file)
-            .write_str(&format!("This is {}", file))
+            .write_str(&format!("This is {file}"))
             .expect("Couldn't write to file");
     }
     for directory in DIRECTORIES {
@@ -59,8 +59,8 @@ pub fn tmpdir() -> TempDir {
                     continue;
                 }
                 tmpdir
-                    .child(format!("{}{}", directory, file))
-                    .write_str(&format!("This is {}{}", directory, file))
+                    .child(format!("{directory}{file}"))
+                    .write_str(&format!("This is {directory}{file}"))
                     .expect("Couldn't write to file");
             }
         }
@@ -109,11 +109,11 @@ where
 pub fn wait_for_port(port: u16) {
     let start_wait = Instant::now();
 
-    while !port_check::is_port_reachable(format!("localhost:{}", port)) {
+    while !port_check::is_port_reachable(format!("localhost:{port}")) {
         sleep(Duration::from_millis(100));
 
         if start_wait.elapsed().as_secs() > 1 {
-            panic!("timeout waiting for port {}", port);
+            panic!("timeout waiting for port {port}");
         }
     }
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -72,7 +72,7 @@ fn get_dir_simple(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
         "text/html; charset=utf-8"
     );
     let text = resp.text().unwrap();
-    assert!(text.split("\n").find(|v| *v == "index.html").is_some());
+    assert!(text.split('\n').any(|v| v == "index.html"));
     Ok(())
 }
 
@@ -118,7 +118,7 @@ fn get_dir_search3(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
     let resp = reqwest::blocking::get(format!("{}?q={}&simple", server.url(), "test.html"))?;
     assert_eq!(resp.status(), 200);
     let text = resp.text().unwrap();
-    assert!(text.split("\n").find(|v| *v == "test.html").is_some());
+    assert!(text.split('\n').any(|v| v == "test.html"));
     Ok(())
 }
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -3,6 +3,7 @@ mod utils;
 
 use fixtures::{server, Error, TestServer};
 use rstest::rstest;
+use serde_json::Value;
 
 #[rstest]
 fn get_dir(server: TestServer) -> Result<(), Error> {
@@ -50,6 +51,32 @@ fn get_dir_zip(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
 }
 
 #[rstest]
+fn get_dir_json(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
+    let resp = reqwest::blocking::get(format!("{}?json", server.url()))?;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "application/json"
+    );
+    let json: Value = serde_json::from_str(&resp.text().unwrap()).unwrap();
+    assert!(json["paths"].as_array().is_some());
+    Ok(())
+}
+
+#[rstest]
+fn get_dir_simple(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
+    let resp = reqwest::blocking::get(format!("{}?simple", server.url()))?;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "text/html; charset=utf-8"
+    );
+    let text = resp.text().unwrap();
+    assert!(text.split("\n").find(|v| *v == "index.html").is_some());
+    Ok(())
+}
+
+#[rstest]
 fn head_dir_zip(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
     let resp = fetch!(b"HEAD", format!("{}?zip", server.url())).send()?;
     assert_eq!(resp.status(), 200);
@@ -83,6 +110,15 @@ fn get_dir_search2(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
     for p in paths {
         assert!(p.contains("😀.bin"));
     }
+    Ok(())
+}
+
+#[rstest]
+fn get_dir_search3(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
+    let resp = reqwest::blocking::get(format!("{}?q={}&simple", server.url(), "test.html"))?;
+    assert_eq!(resp.status(), 200);
+    let text = resp.text().unwrap();
+    assert!(text.split("\n").find(|v| *v == "test.html").is_some());
     Ok(())
 }
 

--- a/tests/log_http.rs
+++ b/tests/log_http.rs
@@ -31,7 +31,7 @@ fn log_remote_user(
 
     let stdout = child.stdout.as_mut().expect("Failed to get stdout");
 
-    let req = fetch!(b"GET", &format!("http://localhost:{}", port));
+    let req = fetch!(b"GET", &format!("http://localhost:{port}"));
 
     let resp = if is_basic {
         req.basic_auth("user", Some("pass")).send()?
@@ -66,7 +66,7 @@ fn no_log(tmpdir: TempDir, port: u16, #[case] args: &[&str]) -> Result<(), Error
 
     let stdout = child.stdout.as_mut().expect("Failed to get stdout");
 
-    let resp = fetch!(b"GET", &format!("http://localhost:{}", port)).send()?;
+    let resp = fetch!(b"GET", &format!("http://localhost:{port}")).send()?;
     assert_eq!(resp.status(), 200);
 
     let mut buf = [0; 1000];

--- a/tests/single_file.rs
+++ b/tests/single_file.rs
@@ -21,11 +21,11 @@ fn single_file(tmpdir: TempDir, port: u16, #[case] file: &str) -> Result<(), Err
 
     wait_for_port(port);
 
-    let resp = reqwest::blocking::get(format!("http://localhost:{}", port))?;
+    let resp = reqwest::blocking::get(format!("http://localhost:{port}"))?;
     assert_eq!(resp.text()?, "This is index.html");
-    let resp = reqwest::blocking::get(format!("http://localhost:{}/", port))?;
+    let resp = reqwest::blocking::get(format!("http://localhost:{port}/"))?;
     assert_eq!(resp.text()?, "This is index.html");
-    let resp = reqwest::blocking::get(format!("http://localhost:{}/index.html", port))?;
+    let resp = reqwest::blocking::get(format!("http://localhost:{port}/index.html"))?;
     assert_eq!(resp.text()?, "This is index.html");
 
     child.kill()?;
@@ -46,13 +46,13 @@ fn path_prefix_single_file(tmpdir: TempDir, port: u16, #[case] file: &str) -> Re
 
     wait_for_port(port);
 
-    let resp = reqwest::blocking::get(format!("http://localhost:{}/xyz", port))?;
+    let resp = reqwest::blocking::get(format!("http://localhost:{port}/xyz"))?;
     assert_eq!(resp.text()?, "This is index.html");
-    let resp = reqwest::blocking::get(format!("http://localhost:{}/xyz/", port))?;
+    let resp = reqwest::blocking::get(format!("http://localhost:{port}/xyz/"))?;
     assert_eq!(resp.text()?, "This is index.html");
-    let resp = reqwest::blocking::get(format!("http://localhost:{}/xyz/index.html", port))?;
+    let resp = reqwest::blocking::get(format!("http://localhost:{port}/xyz/index.html"))?;
     assert_eq!(resp.text()?, "This is index.html");
-    let resp = reqwest::blocking::get(format!("http://localhost:{}", port))?;
+    let resp = reqwest::blocking::get(format!("http://localhost:{port}"))?;
     assert_eq!(resp.status(), 404);
 
     child.kill()?;

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -7,9 +7,9 @@ use rstest::rstest;
 #[rstest]
 fn ls_dir_sort_by_name(server: TestServer) -> Result<(), Error> {
     let url = server.url();
-    let resp = reqwest::blocking::get(format!("{}?sort=name&order=asc", url))?;
+    let resp = reqwest::blocking::get(format!("{url}?sort=name&order=asc"))?;
     let paths1 = self::utils::retrieve_index_paths(&resp.text()?);
-    let resp = reqwest::blocking::get(format!("{}?sort=name&order=desc", url))?;
+    let resp = reqwest::blocking::get(format!("{url}?sort=name&order=desc"))?;
     let mut paths2 = self::utils::retrieve_index_paths(&resp.text()?);
     paths2.reverse();
     assert_eq!(paths1, paths2);
@@ -19,9 +19,9 @@ fn ls_dir_sort_by_name(server: TestServer) -> Result<(), Error> {
 #[rstest]
 fn search_dir_sort_by_name(server: TestServer) -> Result<(), Error> {
     let url = server.url();
-    let resp = reqwest::blocking::get(format!("{}?q={}&sort=name&order=asc", url, "test.html"))?;
+    let resp = reqwest::blocking::get(format!("{url}?q=test.html&sort=name&order=asc"))?;
     let paths1 = self::utils::retrieve_index_paths(&resp.text()?);
-    let resp = reqwest::blocking::get(format!("{}?q={}&sort=name&order=desc", url, "test.html"))?;
+    let resp = reqwest::blocking::get(format!("{url}?q=test.html&sort=name&order=desc"))?;
     let mut paths2 = self::utils::retrieve_index_paths(&resp.text()?);
     paths2.reverse();
     assert_eq!(paths1, paths2);

--- a/tests/symlink.rs
+++ b/tests/symlink.rs
@@ -22,7 +22,7 @@ fn default_not_allow_symlink(server: TestServer, tmpdir: TempDir) -> Result<(), 
     let resp = reqwest::blocking::get(server.url())?;
     let paths = utils::retrieve_index_paths(&resp.text()?);
     assert!(!paths.is_empty());
-    assert!(!paths.contains(&format!("{}/", dir)));
+    assert!(!paths.contains(&format!("{dir}/")));
     Ok(())
 }
 
@@ -41,6 +41,6 @@ fn allow_symlink(
     let resp = reqwest::blocking::get(server.url())?;
     let paths = utils::retrieve_index_paths(&resp.text()?);
     assert!(!paths.is_empty());
-    assert!(paths.contains(&format!("{}/", dir)));
+    assert!(paths.contains(&format!("{dir}/")));
     Ok(())
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -48,7 +48,7 @@ fn retrieve_index_paths_impl(index: &str) -> Option<IndexSet<String>> {
             let name = v.get("name")?.as_str()?;
             let path_type = v.get("path_type")?.as_str()?;
             if path_type.ends_with("Dir") {
-                Some(format!("{}/", name))
+                Some(format!("{name}/"))
             } else {
                 Some(name.to_owned())
             }


### PR DESCRIPTION
use `?simple` to output path name only.
use `?json` to output paths in json format.
By default, output html page.

close #166