### PR TITLE
fix: cors allow-request-header add content-type

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1101,7 +1101,7 @@ fn add_cors(res: &mut Response) {
     );
     res.headers_mut().insert(
         "Access-Control-Allow-Headers",
-        HeaderValue::from_static("Authorization,Destination,Range"),
+        HeaderValue::from_static("Authorization,Destination,Range,Content-Type"),
     );
     res.headers_mut().insert(
         "Access-Control-Expose-Headers",

--- a/tests/cors.rs
+++ b/tests/cors.rs
@@ -23,7 +23,7 @@ fn cors(#[with(&["--enable-cors"])] server: TestServer) -> Result<(), Error> {
     );
     assert_eq!(
         resp.headers().get("access-control-allow-headers").unwrap(),
-        "Authorization,Destination,Range"
+        "Authorization,Destination,Range,Content-Type"
     );
     assert_eq!(
         resp.headers().get("access-control-expose-headers").unwrap(),


### PR DESCRIPTION
cors upload `docx, excel` files need content-type 