### PR TITLE
feat: guess plain text encoding then set content-type charset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +436,7 @@ dependencies = [
  "async-stream",
  "async_zip",
  "base64 0.21.0",
+ "chardetng",
  "chrono",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ form_urlencoded = "1.0"
 alphanumeric-sort = "1.4"
 content_inspector = "0.2"
 anyhow = "1.0"
+chardetng = "0.1"
 
 [features]
 default = ["tls"]

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -46,15 +46,12 @@ pub fn tmpdir() -> TempDir {
     let tmpdir = assert_fs::TempDir::new().expect("Couldn't create a temp dir for tests");
     for file in FILES {
         if *file == BIN_FILE {
-            tmpdir
-                .child(file)
-                .write_binary(b"bin\0\0123")
-                .expect("Couldn't write to file");
+            tmpdir.child(file).write_binary(b"bin\0\0123").unwrap();
         } else {
             tmpdir
                 .child(file)
                 .write_str(&format!("This is {file}"))
-                .expect("Couldn't write to file");
+                .unwrap();
         }
     }
     for directory in DIRECTORIES {
@@ -62,7 +59,7 @@ pub fn tmpdir() -> TempDir {
             tmpdir
                 .child(format!("{}{}", directory, "index.html"))
                 .write_str("__ASSERTS_PREFIX__index.js;DATA = __INDEX_DATA__")
-                .expect("Couldn't write to file");
+                .unwrap();
         } else {
             for file in FILES {
                 if *directory == DIR_NO_INDEX && *file == "index.html" {
@@ -72,17 +69,37 @@ pub fn tmpdir() -> TempDir {
                     tmpdir
                         .child(format!("{directory}{file}"))
                         .write_binary(b"bin\0\0123")
-                        .expect("Couldn't write to file");
+                        .unwrap();
                 } else {
                     tmpdir
                         .child(format!("{directory}{file}"))
                         .write_str(&format!("This is {directory}{file}"))
-                        .expect("Couldn't write to file");
+                        .unwrap();
                 }
             }
         }
     }
     tmpdir.child("dir4/hidden").touch().unwrap();
+    tmpdir
+        .child("content-types/bin.tar")
+        .write_binary(b"\x7f\x45\x4c\x46\x02\x01\x00\x00")
+        .unwrap();
+    tmpdir
+        .child("content-types/bin")
+        .write_binary(b"\x7f\x45\x4c\x46\x02\x01\x00\x00")
+        .unwrap();
+    tmpdir
+        .child("content-types/file-utf8.txt")
+        .write_str("世界")
+        .unwrap();
+    tmpdir
+        .child("content-types/file-gbk.txt")
+        .write_binary(b"\xca\xc0\xbd\xe7")
+        .unwrap();
+    tmpdir
+        .child("content-types/file")
+        .write_str("世界")
+        .unwrap();
 
     tmpdir
 }


### PR DESCRIPTION
Both issue #185 and issue #105 are related to encoding.

Although it is not 100% accurate to know the encoding of a text file. 
A guess encoding is correct most of the timeis. It's better than just displaying garbled characters.

