### PR TITLE
Show precise file size with two decimal places when size >= 1GB

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -778,7 +778,11 @@ function formatSize(size) {
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
   if (size == 0) return [0, "B"];
   const i = parseInt(Math.floor(Math.log(size) / Math.log(1024)));
-  return [Math.round(size / Math.pow(1024, i), 2), sizes[i]];
+  ratio = 1
+  if (i >= 3) {
+    ratio = 100
+  }
+  return [Math.round(size * ratio / Math.pow(1024, i), 2) / ratio, sizes[i]];
 }
 
 function formatDuration(seconds) {


### PR DESCRIPTION
Manually tested and the displayed file size is like:
* 5.18 GB instead of 5 GB
* 1.7 GB instead of 2 GB
* 104 MB is still 104 MB
* 33 B is still 33 B