### PR TITLE
feat: new auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ content_inspector = "0.2"
 anyhow = "1.0"
 chardetng = "0.1"
 glob = "0.3.1"
+indexmap = "1.9"
 
 [features]
 default = ["tls"]
@@ -59,7 +60,6 @@ regex = "1"
 url = "2"
 diqwest = { version = "1", features = ["blocking"] }
 predicates = "3"
-indexmap = "1.9"
 
 [profile.release]
 lto = true

--- a/src/args.rs
+++ b/src/args.rs
@@ -78,7 +78,7 @@ pub fn build_cli() -> Command {
                 .long("auth")
                 .help("Add auth for path")
                 .action(ArgAction::Append)
-                .value_delimiter(',')
+                .value_delimiter('|')
                 .value_name("rules"),
         )
         .arg(
@@ -288,7 +288,7 @@ impl Args {
             "basic" => AuthMethod::Basic,
             _ => AuthMethod::Digest,
         };
-        let auth = AccessControl::new(&auth, &uri_prefix)?;
+        let auth = AccessControl::new(&auth)?;
         let allow_upload = matches.get_flag("allow-all") || matches.get_flag("allow-upload");
         let allow_delete = matches.get_flag("allow-all") || matches.get_flag("allow-delete");
         let allow_search = matches.get_flag("allow-all") || matches.get_flag("allow-search");

--- a/tests/log_http.rs
+++ b/tests/log_http.rs
@@ -11,8 +11,8 @@ use std::io::Read;
 use std::process::{Command, Stdio};
 
 #[rstest]
-#[case(&["-a", "/@user:pass", "--log-format", "$remote_user"], false)]
-#[case(&["-a", "/@user:pass", "--log-format", "$remote_user", "--auth-method", "basic"], true)]
+#[case(&["-a", "user:pass@/:rw", "--log-format", "$remote_user"], false)]
+#[case(&["-a", "user:pass@/:rw", "--log-format", "$remote_user", "--auth-method", "basic"], true)]
 fn log_remote_user(
     tmpdir: TempDir,
     port: u16,

--- a/tests/single_file.rs
+++ b/tests/single_file.rs
@@ -53,7 +53,7 @@ fn path_prefix_single_file(tmpdir: TempDir, port: u16, #[case] file: &str) -> Re
     let resp = reqwest::blocking::get(format!("http://localhost:{port}/xyz/index.html"))?;
     assert_eq!(resp.text()?, "This is index.html");
     let resp = reqwest::blocking::get(format!("http://localhost:{port}"))?;
-    assert_eq!(resp.status(), 404);
+    assert_eq!(resp.status(), 403);
 
     child.kill()?;
     Ok(())


### PR DESCRIPTION
The access level path control used by dufs has two disadvantages:

1. One path cannot support multiple users
2. It is very troublesome to set multiple paths for one user

So it needs to be refactored.
The new auth is account based, it closes #207, closes #208.

### Access Control

Dufs supports account based access control. You can control who can do what on which path with `--auth`/`-a`.

```
dufs -a [user:pass]@path[:rw][,path[:rw]...][|...]
```
1: Multiple rules are separated by "|"
2: User and pass are the account name and password, if omitted, it is an anonymous user
3: One rule can set multiple paths, separated by ","
4: Add `:rw` after the path to indicate that the path has read and write permissions, otherwise the path has readonly permissions.

```
dufs -A -a admin:admin@/:rw
```
`admin` has all permissions for all paths.

```
dufs -A -a admin:admin@/:rw -a guest:guest@/
```
`guest` has readonly permissions for all paths.

```
dufs -A -a admin:admin@/:rw -a @/
```
All paths is public, everyone can view/download it.

```
dufs -A -a admin:admin@/:rw -a user1:pass1@/user1:rw -a user2:pass2@/user2
dufs -A -a "admin:admin@/:rw|user1:pass1@/user1:rw|user2:pass2@/user2"
```
`user1` has all permissions for `/user1/*` path.
`user2` has all permissions for `/user2/*` path.

```
dufs -A -a user:pass@/dir1:rw,/dir2:rw,dir3
```
`user` has all permissions for `/dir1/*` and `/dir2/*`, has readonly permissions for `/dir3/`.

```
dufs -a admin:admin@/
```
Since dufs only allows viewing/downloading, `admin` can only view/download files.

BREAKING CHANGE: new auth
