### PR TITLE
fix: ui path table show move action

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -148,7 +148,7 @@ body {
 }
 
 .paths-table .cell-actions {
-  width: 75px;
+  width: 90px;
   display: flex;
   padding-left: 0.6em;
 }

--- a/assets/index.js
+++ b/assets/index.js
@@ -379,9 +379,8 @@ function addPath(file, index) {
   }
   if (DATA.allow_delete) {
     if (DATA.allow_upload) {
-      if (isDir) {
-        actionMove = `<div onclick="movePath(${index})" class="action-btn" id="moveBtn${index}" title="Move to new path">${ICONS.move}</div>`;
-      } else {
+      actionMove = `<div onclick="movePath(${index})" class="action-btn" id="moveBtn${index}" title="Move to new path">${ICONS.move}</div>`;
+      if (!isDir) {
         actionEdit = `<a class="action-btn" title="Edit file" target="_blank" href="${url}?edit">${ICONS.edit}</a>`;
       }
     }
@@ -392,8 +391,8 @@ function addPath(file, index) {
   <td class="cell-actions">
     ${actionDownload}
     ${actionMove}
-    ${actionEdit}
     ${actionDelete}
+    ${actionEdit}
   </td>`
 
   $pathsTableBody.insertAdjacentHTML("beforeend", `


### PR DESCRIPTION
Considering that some users cannot find the move operation of the file

![image](https://github.com/sigoden/dufs/assets/4012553/44cb9a30-7090-4d98-b20d-6874bfedd181)