### PR TITLE
server: allow more webdav related header with CORS

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1290,7 +1290,9 @@ fn add_cors(res: &mut Response) {
     );
     res.headers_mut().insert(
         "Access-Control-Allow-Headers",
-        HeaderValue::from_static("Authorization,Destination,Range,Content-Type"),
+        HeaderValue::from_static(
+            "Authorization,Destination,Range,Content-Type,Cache-Control,Overwrite",
+        ),
     );
     res.headers_mut().insert(
         "Access-Control-Expose-Headers",

--- a/tests/cors.rs
+++ b/tests/cors.rs
@@ -23,7 +23,7 @@ fn cors(#[with(&["--enable-cors"])] server: TestServer) -> Result<(), Error> {
     );
     assert_eq!(
         resp.headers().get("access-control-allow-headers").unwrap(),
-        "Authorization,Destination,Range,Content-Type"
+        "Authorization,Destination,Range,Content-Type,Cache-Control,Overwrite"
     );
     assert_eq!(
         resp.headers().get("access-control-expose-headers").unwrap(),


### PR DESCRIPTION
`Overwrite` is used with COPY or MOVE ( http://www.webdav.org/specs/rfc2518.html#HEADER_Overwrite )

`Cache-Control` can be set by client to disable cache.

Fixes #221