### PR TITLE
fix: ui refresh page after login

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -445,6 +445,7 @@ function setupAuth() {
     $loginBtn.addEventListener("click", async () => {
       try {
         await checkAuth()
+        location.reload();
       } catch (err) {
         alert(err.message);
       }


### PR DESCRIPTION
There is a situation where you can only see part of the directory before logging in, but you can see all the directories after logging in.

So it is necessary to refresh the page after successful login