### PR TITLE
chore: expose port 5000 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
 FROM scratch
 COPY --from=builder /bin/dufs /bin/dufs
 STOPSIGNAL SIGINT
+EXPOSE 5000
 ENTRYPOINT ["/bin/dufs"]


### PR DESCRIPTION
Hello,

I am using traefik as reverse-proxy for dufs.

Both are docker images and to enable [traefik automatic port detection](https://doc.traefik.io/traefik/providers/docker/#port-detection), dufs needs to [expose](https://docs.docker.com/engine/reference/builder/#expose) his port.

This is my use case, but I suppose that other tools may rely on the expose to do some automatic detection.

I really like dufs, it is a great product that goes straight to the point.