### PR TITLE
feat: empty search '?q=' list all paths

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -499,15 +499,7 @@ impl Server {
             .to_lowercase();
         if search.is_empty() {
             return self
-                .handle_ls_dir(
-                    path,
-                    true,
-                    &query_params,
-                    head_only,
-                    user,
-                    access_paths,
-                    res,
-                )
+                .handle_ls_dir(path, true, query_params, head_only, user, access_paths, res)
                 .await;
         } else {
             let path_buf = path.to_path_buf();

--- a/src/server.rs
+++ b/src/server.rs
@@ -497,7 +497,19 @@ impl Server {
             .get("q")
             .ok_or_else(|| anyhow!("invalid q"))?
             .to_lowercase();
-        if !search.is_empty() {
+        if search.is_empty() {
+            return self
+                .handle_ls_dir(
+                    path,
+                    true,
+                    &query_params,
+                    head_only,
+                    user,
+                    access_paths,
+                    res,
+                )
+                .await;
+        } else {
             let path_buf = path.to_path_buf();
             let hidden = Arc::new(self.args.hidden.to_vec());
             let hidden = hidden.clone();

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -147,9 +147,7 @@ fn head_dir_search(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
 #[rstest]
 fn empty_search(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
     let resp = reqwest::blocking::get(format!("{}?q=", server.url()))?;
-    assert_eq!(resp.status(), 200);
-    let paths = utils::retrieve_index_paths(&resp.text()?);
-    assert!(paths.is_empty());
+    assert_resp_paths!(resp);
     Ok(())
 }
 


### PR DESCRIPTION
In the past, an empty search "/?q=" would return empty paths.
After this pr, an empty search "/?q=" will list all paths, just like no '?q='.