### PR TITLE
fix: auth precedence

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -514,7 +514,7 @@ impl Server {
             let access_paths = access_paths.clone();
             let search_paths = tokio::task::spawn_blocking(move || {
                 let mut paths: Vec<PathBuf> = vec![];
-                for dir in access_paths.leaf_paths(&path_buf) {
+                for dir in access_paths.child_paths(&path_buf) {
                     let mut it = WalkDir::new(&dir).into_iter();
                     it.next();
                     while let Some(Ok(entry)) = it.next() {
@@ -1184,7 +1184,7 @@ impl Server {
     ) -> Result<Vec<PathItem>> {
         let mut paths: Vec<PathItem> = vec![];
         if access_paths.perm().indexonly() {
-            for name in access_paths.child_paths() {
+            for name in access_paths.child_names() {
                 let entry_path = entry_path.join(name);
                 self.add_pathitem(&mut paths, base_path, &entry_path).await;
             }
@@ -1465,7 +1465,7 @@ async fn zip_dir<W: AsyncWrite + Unpin>(
     let dir_clone = dir.to_path_buf();
     let zip_paths = tokio::task::spawn_blocking(move || {
         let mut paths: Vec<PathBuf> = vec![];
-        for dir in access_paths.leaf_paths(&dir_clone) {
+        for dir in access_paths.child_paths(&dir_clone) {
             let mut it = WalkDir::new(&dir).into_iter();
             it.next();
             while let Some(Ok(entry)) = it.next() {

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -282,3 +282,22 @@ fn auth_data(
     assert_eq!(json["allow_upload"], serde_json::Value::Bool(true));
     Ok(())
 }
+
+#[rstest]
+fn auth_precedence(
+    #[with(&["--auth", "user:pass@/dir1:rw,/dir1/test.txt", "-A"])] server: TestServer,
+) -> Result<(), Error> {
+    let url = format!("{}dir1/test.txt", server.url());
+    let resp = fetch!(b"PUT", &url)
+        .body(b"abc".to_vec())
+        .send_with_digest_auth("user", "pass")?;
+    assert_eq!(resp.status(), 403);
+
+    let url = format!("{}dir1/file1", server.url());
+    let resp = fetch!(b"PUT", &url)
+        .body(b"abc".to_vec())
+        .send_with_digest_auth("user", "pass")?;
+    assert_eq!(resp.status(), 201);
+
+    Ok(())
+}


### PR DESCRIPTION
The more specific a path is, the higher its priority.

Let me take `user:pass@/dir1:rw,/dir1/test.txt` as an example:
`/dir1/test.txt` will be readonly, as `/dir1/test.txt` is more specific than `/dir1:rw`.