### PR TITLE
feat: auth supports forbidden permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ curl http://192.168.8.10:5000/file --user user:pass --digest        # digest aut
 Dufs supports account based access control. You can control who can do what on which path with `--auth`/`-a`.
 
 ```
-dufs -a user:pass@/dir1:rw,/dir2,/dir2/sub1:- -a user2:pass2@/dir3 -a @/
+dufs -a admin:admin@/:rw -a guest:guest@/
+dufs -a user:pass@/:rw,/dir1,/dir2:- -a @/
 ```
 
 1. Use `@` to separate the account and paths. No account means anonymous user.
@@ -215,13 +216,12 @@ dufs -a user:pass@/dir1:rw,/dir2,/dir2/sub1:- -a user2:pass2@/dir3 -a @/
 3. Use `,` to separate paths.
 4. Use path suffix `:rw`, `:ro`, `:-` to set permissions: `read-write`, `read-only`, `forbidden`. `:ro` can be omitted.
 
-
-- `-a admin:amdin@/:rw`: `admin` has complete permissions for all paths.
+- `-a admin:admin@/:rw`: `admin` has complete permissions for all paths.
 - `-a guest:guest@/`: `guest` has read-only permissions for all paths.
-- `-a user:pass@/dir1:rw,/dir2,/dir2/sub:-`: `user` has read-write permissions for `/dir1/*`, has read-only permissions for `/dir2/*`, but is fordden for `/dir2/sub1`.
+- `-a user:pass@/:rw,/dir1,/dir2:-`: `user` has read-write permissions for `/*`, has read-only permissions for `/dir1/*`, but is fordden for `/dir2/*`.
 - `-a @/`: All paths is publicly accessible, everyone can view/download it.
 
-> There are no restrictions on using ':' and '@' characters in a password, `user:pa:ss@1@/:rw` is valid, and the password is `pa:ss@1`.
+> There are no restrictions on using ':' and '@' characters in a password. For example, `user:pa:ss@1@/:rw` is valid, the password is `pa:ss@1`.
 
 #### Hashed Password
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ dufs -a user:pass@/dir1:rw,/dir2,/dir2/sub1:- -a user2:pass2@/dir3 -a @/
 1. Use `@` to separate the account and paths. No account means anonymous user.
 2. Use `:` to separate the username and password of the account.
 3. Use `,` to separate paths.
-4. Use `:rw`, `:ro`, `:-`  to set permissions: `read-write`, `read-only`(optional), `forbidden`.
+4. Use path suffix `:rw`, `:ro`, `:-` to set permissions: `read-write`, `read-only`, `forbidden`. `:ro` can be omitted.
 
 
 - `-a admin:amdin@/:rw`: `admin` has complete permissions for all paths.

--- a/README.md
+++ b/README.md
@@ -207,17 +207,18 @@ curl http://192.168.8.10:5000/file --user user:pass --digest        # digest aut
 Dufs supports account based access control. You can control who can do what on which path with `--auth`/`-a`.
 
 ```
-dufs -a user:pass@/path1:rw,/path2 -a user2:pass2@/path3 -a @/path4
+dufs -a user:pass@/dir1:rw,/dir2,/dir2/sub1:- -a user2:pass2@/dir3 -a @/
 ```
 
 1. Use `@` to separate the account and paths. No account means anonymous user.
 2. Use `:` to separate the username and password of the account.
 3. Use `,` to separate paths.
-4. Use `:rw` suffix to indicate that the account has read-write permission on the path.
+4. Use `:rw`, `:ro`, `:-`  to set permissions: `read-write`, `read-only`(optional), `forbidden`.
+
 
 - `-a admin:amdin@/:rw`: `admin` has complete permissions for all paths.
 - `-a guest:guest@/`: `guest` has read-only permissions for all paths.
-- `-a user:pass@/dir1:rw,/dir2`: `user` has complete permissions for `/dir1/*`, has read-only permissions for `/dir2/`.
+- `-a user:pass@/dir1:rw,/dir2,/dir2/sub:-`: `user` has read-write permissions for `/dir1/*`, has read-only permissions for `/dir2/*`, but is fordden for `/dir2/sub1`.
 - `-a @/`: All paths is publicly accessible, everyone can view/download it.
 
 > There are no restrictions on using ':' and '@' characters in a password, `user:pa:ss@1@/:rw` is valid, and the password is `pa:ss@1`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -345,7 +345,7 @@ impl Server {
             method => match method.as_str() {
                 "PROPFIND" => {
                     if is_dir {
-                        let access_paths = if access_paths.perm().indexonly() {
+                        let access_paths = if access_paths.perm().inherit() {
                             // see https://github.com/sigoden/dufs/issues/229
                             AccessPaths::new(AccessPerm::ReadOnly)
                         } else {
@@ -1183,7 +1183,7 @@ impl Server {
         access_paths: AccessPaths,
     ) -> Result<Vec<PathItem>> {
         let mut paths: Vec<PathItem> = vec![];
-        if access_paths.perm().indexonly() {
+        if access_paths.perm().inherit() {
             for name in access_paths.child_names() {
                 let entry_path = entry_path.join(name);
                 self.add_pathitem(&mut paths, base_path, &entry_path).await;

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -145,6 +145,23 @@ fn auth_readonly(
 }
 
 #[rstest]
+fn auth_forbidden(
+    #[with(&["--auth", "user:pass@/:rw,/dir1:-", "-A"])] server: TestServer,
+) -> Result<(), Error> {
+    let url = format!("{}file1", server.url());
+    let resp = fetch!(b"PUT", &url)
+        .body(b"abc".to_vec())
+        .send_with_digest_auth("user", "pass")?;
+    assert_eq!(resp.status(), 201);
+    let url = format!("{}dir1/file1", server.url());
+    let resp = fetch!(b"PUT", &url)
+        .body(b"abc".to_vec())
+        .send_with_digest_auth("user", "pass")?;
+    assert_eq!(resp.status(), 403);
+    Ok(())
+}
+
+#[rstest]
 fn auth_nest(
     #[with(&["--auth", "user:pass@/:rw", "--auth", "user2:pass2@/", "--auth", "user3:pass3@/dir1:rw", "-A"])]
     server: TestServer,


### PR DESCRIPTION
Use `:-` to indicate that the path is forbidden.
```
dufs -a user:pass@/:rw,/dir1,/dir2:-
```
`user` has read-write permissions for `/*`, has read-only permissions for `/dir1/*`, but is fordden for `/dir2/*`.