### PR TITLE
feat: supports resumable uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Resumable uploads
 ```
 upload_offset=$(curl -I -s http://127.0.0.1:5000/file | tr -d '\r' | sed -n 's/content-length: //p')
 dd skip=$upload_offset if=file status=none ibs=1 | \
-  curl -X PATCH -H "Upload-Offset: $upload_offset" --data-binary @- http://127.0.0.1:5000/file
+  curl -X PATCH -H "X-Update-Range: append" --data-binary @- http://127.0.0.1:5000/file
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ curl -C- -o file http://127.0.0.1:5000/file
 Resumable uploads
 
 ```
-upload_offset=$(curl -I -s http://127.0.0.1:5000/file | tr -d '\r' | sed -n 's/upload-offset: //p')
+upload_offset=$(curl -I -s http://127.0.0.1:5000/file | tr -d '\r' | sed -n 's/content-length: //p')
 dd skip=$upload_offset if=file status=none ibs=1 | \
   curl -X PATCH -H "Upload-Offset: $upload_offset" --data-binary @- http://127.0.0.1:5000/file
 ```

--- a/README.md
+++ b/README.md
@@ -208,10 +208,9 @@ curl -C- -o file http://127.0.0.1:5000/file
 Resumable upload
 
 ```
-# Check the status of a resumable upload
-curl -i -X PUT -d '' -H "CONTENT-RANGE: bytes */$SIZE" http://localhost:5000/file 
-# Resume an interrupted upload
-curl -T remainder -H "Content-Range: bytes $NEXT_BYTE-$LAST_BYTE/$SIZE" http://localhost:5000/file
+upload_offset=$(curl -I -s http://127.0.0.1:5000/file | tr -d '\r' | sed -n 's/upload-offset: //p')
+dd skip=$upload_offset if=file of=remainder ibs=1
+curl -X PATCH -H "Upload-Offset: $upload_offset" -T remainder  http://127.0.0.1:5000/file
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -199,13 +199,13 @@ curl http://127.0.0.1:5000/file --user user:pass                 # basic auth
 curl http://127.0.0.1:5000/file --user user:pass --digest        # digest auth
 ```
 
-Resumable download
+Resumable downloads
 
 ```
 curl -C- -o file http://127.0.0.1:5000/file
 ```
 
-Resumable upload
+Resumable uploads
 
 ```
 upload_offset=$(curl -I -s http://127.0.0.1:5000/file | tr -d '\r' | sed -n 's/upload-offset: //p')

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Resumable upload
 
 ```
 upload_offset=$(curl -I -s http://127.0.0.1:5000/file | tr -d '\r' | sed -n 's/upload-offset: //p')
-dd skip=$upload_offset if=file status=none | \
+dd skip=$upload_offset if=file status=none ibs=1 | \
   curl -X PATCH -H "Upload-Offset: $upload_offset" --data-binary @- http://127.0.0.1:5000/file
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dufs is a distinctive utility file server that supports static serving, uploadin
 - Download folder as zip file
 - Upload files and folders (Drag & Drop)
 - Create/Edit/Search files
-- Partial responses (Parallel/Resume download)
+- Resumable/partial uploads/downloads
 - Access control
 - Support https
 - Support webdav
@@ -195,8 +195,23 @@ curl http://127.0.0.1:5000?json                   # output paths in json format
 With authorization
 
 ```
-curl http://192.168.8.10:5000/file --user user:pass                 # basic auth
-curl http://192.168.8.10:5000/file --user user:pass --digest        # digest auth
+curl http://127.0.0.1:5000/file --user user:pass                 # basic auth
+curl http://127.0.0.1:5000/file --user user:pass --digest        # digest auth
+```
+
+Resumable download
+
+```
+curl -C- -o file http://127.0.0.1:5000/file
+```
+
+Resumable upload
+
+```
+# Check the status of a resumable upload
+curl -i -X PUT -d '' -H "CONTENT-RANGE: bytes */$SIZE" http://localhost:5000/file 
+# Resume an interrupted upload
+curl -T remainder -H "Content-Range: bytes $NEXT_BYTE-$LAST_BYTE/$SIZE" http://localhost:5000/file
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ Resumable upload
 
 ```
 upload_offset=$(curl -I -s http://127.0.0.1:5000/file | tr -d '\r' | sed -n 's/upload-offset: //p')
-dd skip=$upload_offset if=file of=remainder ibs=1
-curl -X PATCH -H "Upload-Offset: $upload_offset" -T remainder  http://127.0.0.1:5000/file
+dd skip=$upload_offset if=file status=none | \
+  curl -X PATCH -H "Upload-Offset: $upload_offset" --data-binary @- http://127.0.0.1:5000/file
 ```
 
 <details>

--- a/assets/index.css
+++ b/assets/index.css
@@ -134,7 +134,6 @@ body {
 }
 
 .cell-status span {
-  width: 80px;
   display: inline-block;
 }
 

--- a/assets/index.css
+++ b/assets/index.css
@@ -238,6 +238,10 @@ body {
   font-style: italic;
 }
 
+.retry-btn {
+  cursor: pointer;
+}
+
 @media (min-width: 768px) {
   .path a {
     min-width: 400px;

--- a/assets/index.js
+++ b/assets/index.js
@@ -60,6 +60,11 @@ const ICONS = {
 }
 
 /**
+ * @type Map<string, Uploader>
+ */
+const failUploaders = new Map();
+
+/**
  * @type Element
  */
 let $pathsTable;
@@ -128,23 +133,23 @@ class Uploader {
   /**
    *
    * @param {File} file
-   * @param {string[]} dirs
+   * @param {string[]} pathParts
    */
-  constructor(file, dirs) {
+  constructor(file, pathParts) {
     /**
      * @type Element
      */
     this.$uploadStatus = null
     this.uploaded = 0;
     this.lastUptime = 0;
-    this.name = [...dirs, file.name].join("/");
+    this.name = [...pathParts, file.name].join("/");
     this.idx = Uploader.globalIdx++;
     this.file = file;
+    this.url = newUrl(this.name);
   }
 
   upload() {
-    const { idx, name } = this;
-    const url = newUrl(name);
+    const { idx, name, url } = this;
     const encodedName = encodedStr(name);
     $uploadersTable.insertAdjacentHTML("beforeend", `
   <tr id="upload${idx}" class="uploader">
@@ -160,12 +165,24 @@ class Uploader {
     $emptyFolder.classList.add("hidden");
     this.$uploadStatus = document.getElementById(`uploadStatus${idx}`);
     this.$uploadStatus.innerHTML = '-';
+    this.$uploadStatus.addEventListener("click", e => {
+      const nodeId = e.target.id;
+      const matches = /^retry(\d+)$/.exec(nodeId);
+      if (matches) {
+        const id = parseInt(matches[1]);
+        let uploader = failUploaders.get(id);
+        if (uploader) uploader.retry();
+      }
+    });
     Uploader.queues.push(this);
     Uploader.runQueue();
   }
 
-  ajax() {
-    const url = newUrl(this.name);
+  /**
+   * @param {number} uploadOffset 
+   */
+  ajax(uploadOffset) {
+    const { url } = this;
     this.lastUptime = Date.now();
     const ajax = new XMLHttpRequest();
     ajax.upload.addEventListener("progress", e => this.progress(e), false);
@@ -174,16 +191,36 @@ class Uploader {
         if (ajax.status >= 200 && ajax.status < 300) {
           this.complete();
         } else {
-          this.fail();
+          if (ajax.status != 0) {
+            this.fail(`${ajax.status} ${ajax.statusText}`);
+          }
         }
       }
     })
     ajax.addEventListener("error", () => this.fail(), false);
     ajax.addEventListener("abort", () => this.fail(), false);
-    ajax.open("PUT", url);
-    ajax.send(this.file);
+    if (uploadOffset > 0) {
+      ajax.open("PATCH", url);
+      ajax.setRequestHeader("Upload-Offset", uploadOffset);
+      ajax.send(this.file.slice(uploadOffset));
+    } else {
+      ajax.open("PUT", url);
+      ajax.send(this.file);
+    }
   }
 
+  async retry() {
+    const { url } = this;
+    let res = await fetch(url, {
+      method: "HEAD",
+    });
+    let uploadOffset = 0;
+    if (res.status == 200) {
+      let value = res.headers.get("upload-offset");
+      uploadOffset = parseInt(value) || 0;
+    }
+    this.ajax(uploadOffset)
+  }
 
   progress(event) {
     const now = Date.now();
@@ -192,19 +229,26 @@ class Uploader {
     const speedText = `${speedValue} ${speedUnit}/s`;
     const progress = formatPercent((event.loaded / event.total) * 100);
     const duration = formatDuration((event.total - event.loaded) / speed)
-    this.$uploadStatus.innerHTML = `<span>${speedText}</span><span>${progress} ${duration}</span>`;
+    this.$uploadStatus.innerHTML = `<span style="width: 80px;">${speedText}</span><span>${progress} ${duration}</span>`;
     this.uploaded = event.loaded;
     this.lastUptime = now;
   }
 
   complete() {
-    this.$uploadStatus.innerHTML = `✓`;
+    this.uploaded = 0;
+    const $uploadStatusNew = this.$uploadStatus.cloneNode(true);
+    $uploadStatusNew.innerHTML = `✓`;
+    this.$uploadStatus.parentNode.replaceChild($uploadStatusNew, this.$uploadStatus);
+    this.$uploadStatus = null;
+    failUploaders.delete(this.idx);
     Uploader.runnings--;
     Uploader.runQueue();
   }
 
-  fail() {
-    this.$uploadStatus.innerHTML = `✗`;
+  fail(reason = "") {
+    this.uploaded = 0;
+    this.$uploadStatus.innerHTML = `<span style="width: 20px;" title="${reason}">✗</span><span class="retry-btn" id="retry${this.idx}" title="Retry">↻</span>`;
+    failUploaders.set(this.idx, this);
     Uploader.runnings--;
     Uploader.runQueue();
   }
@@ -235,7 +279,7 @@ Uploader.runQueue = async () => {
       Uploader.auth = false;
     }
   }
-  uploader.ajax();
+  uploader.ajax(0);
 }
 
 /**
@@ -801,7 +845,7 @@ function padZero(value, size) {
 }
 
 function formatSize(size) {
-  if (size == null) return []
+  if (size == null) return [0, "B"]
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
   if (size == 0) return [0, "B"];
   const i = parseInt(Math.floor(Math.log(size) / Math.log(1024)));

--- a/assets/index.js
+++ b/assets/index.js
@@ -202,11 +202,12 @@ class Uploader {
     ajax.addEventListener("abort", () => this.fail(), false);
     if (this.uploadOffset > 0) {
       ajax.open("PATCH", url);
-      ajax.setRequestHeader("Upload-Offset", this.uploadOffset);
+      ajax.setRequestHeader("X-Update-Range", "append");
       ajax.send(this.file.slice(this.uploadOffset));
     } else {
       ajax.open("PUT", url);
       ajax.send(this.file);
+      // setTimeout(() => ajax.abort(), 3000);
     }
   }
 

--- a/assets/index.js
+++ b/assets/index.js
@@ -206,6 +206,7 @@ class Uploader {
     } else {
       ajax.open("PUT", url);
       ajax.send(this.file);
+      // setTimeout(() => ajax.abort(), 3000); // debug resumable uploading
     }
   }
 

--- a/assets/index.js
+++ b/assets/index.js
@@ -217,7 +217,7 @@ class Uploader {
     });
     let uploadOffset = 0;
     if (res.status == 200) {
-      let value = res.headers.get("upload-offset");
+      let value = res.headers.get("content-length");
       uploadOffset = parseInt(value) || 0;
     }
     this.uploadOffset = uploadOffset;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1723,10 +1723,12 @@ fn guard_upload(
             if start > end
                 || start >= range_size
                 || end >= range_size
-                || (!allow_delete && start != size)
                 || (allow_delete && start > size)
             {
                 status_bad_request(res, message);
+                (true, None)
+            } else if !allow_delete && start != size {
+                status_forbid(res);
                 (true, None)
             } else {
                 (false, Some(start))

--- a/src/server.rs
+++ b/src/server.rs
@@ -58,7 +58,7 @@ const FAVICON_ICO: &[u8] = include_bytes!("../assets/favicon.ico");
 const INDEX_NAME: &str = "index.html";
 const BUF_SIZE: usize = 65536;
 const EDITABLE_TEXT_MAX_SIZE: u64 = 4194304; // 4M
-const RESUMABLE_UPLOAD_MIN_SIZE: u64 = 104857600; // 100M
+const RESUMABLE_UPLOAD_MIN_SIZE: u64 = 20971520; // 20M
 
 pub struct Server {
     args: Args,
@@ -485,11 +485,6 @@ impl Server {
             ret?;
         }
 
-        if upload_offset.is_some() {
-            res.headers_mut()
-                .insert("Upload-Offset", size.to_string().parse()?);
-        }
-
         *res.status_mut() = status;
 
         Ok(())
@@ -817,11 +812,6 @@ impl Server {
         set_content_diposition(res, true, filename)?;
 
         res.headers_mut().typed_insert(AcceptRanges::bytes());
-
-        if head_only {
-            res.headers_mut()
-                .insert("Upload-Offset", size.to_string().parse()?);
-        }
 
         if let Some(range) = range {
             if let Some((start, end)) = range {

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -338,7 +338,7 @@ fn resumable_upload(#[with(&["--allow-upload"])] server: TestServer) -> Result<(
     assert_eq!(resp.status(), 201);
     let resp = fetch!(b"HEAD", &url).send()?;
     assert_eq!(resp.status(), 200);
-    assert_eq!(resp.headers().get("upload-offset").unwrap(), "3");
+    assert_eq!(resp.headers().get("content-length").unwrap(), "3");
     let resp = fetch!(b"PATCH", &url)
         .header("Upload-Offset", "3")
         .body(b"abc".to_vec())

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -332,7 +332,7 @@ fn get_file_content_type(server: TestServer) -> Result<(), Error> {
 }
 
 #[rstest]
-fn resumable_upload(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
+fn resumable_upload(#[with(&["--allow-upload"])] server: TestServer) -> Result<(), Error> {
     let url = format!("{}file1", server.url());
     let resp = fetch!(b"PUT", &url).body(b"abc".to_vec()).send()?;
     assert_eq!(resp.status(), 201);
@@ -350,5 +350,63 @@ fn resumable_upload(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
     let resp = reqwest::blocking::get(url)?;
     assert_eq!(resp.status(), 200);
     assert_eq!(resp.text().unwrap(), "abcabc");
+    Ok(())
+}
+
+#[rstest]
+fn partial_upload(
+    #[with(&["--allow-upload", "--allow-delete"])] server: TestServer,
+) -> Result<(), Error> {
+    let url = format!("{}file1", server.url());
+    let resp = fetch!(b"PUT", &url).body(b"abc".to_vec()).send()?;
+    assert_eq!(resp.status(), 201);
+    let resp = fetch!(b"PUT", &url)
+        .header("content-range", "bytes 0-0/6")
+        .body(b"n".to_vec())
+        .send()?;
+    assert_eq!(resp.status(), 200);
+    let resp = reqwest::blocking::get(url)?;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().unwrap(), "nbc");
+    Ok(())
+}
+
+#[rstest]
+fn upload_content_range(#[with(&["--allow-upload"])] server: TestServer) -> Result<(), Error> {
+    let url = format!("{}file1", server.url());
+    let resp = fetch!(b"PUT", &url).body(b"abc".to_vec()).send()?;
+    assert_eq!(resp.status(), 201);
+    let resp = fetch!(b"PUT", &url)
+        .body(b"abc".to_vec())
+        .header("content-range", "bytes */3")
+        .send()?;
+    assert_eq!(resp.status(), 400);
+    let resp = fetch!(b"PUT", &url)
+        .body(b"bc".to_vec())
+        .header("content-range", "bytes 1-2/3")
+        .send()?;
+    assert_eq!(resp.status(), 403);
+    let resp = fetch!(b"PUT", &url).body(b"abc".to_vec()).send()?;
+    assert_eq!(resp.status(), 403);
+    Ok(())
+}
+
+#[rstest]
+fn upload_content_range_allow_delete(
+    #[with(&["--allow-upload", "--allow-delete"])] server: TestServer,
+) -> Result<(), Error> {
+    let url = format!("{}file1", server.url());
+    let resp = fetch!(b"PUT", &url).body(b"abc".to_vec()).send()?;
+    assert_eq!(resp.status(), 201);
+    let resp = fetch!(b"PUT", &url)
+        .body(b"abc".to_vec())
+        .header("content-range", "bytes 4-6/7")
+        .send()?;
+    assert_eq!(resp.status(), 400);
+    let resp = fetch!(b"PUT", &url)
+        .body(b"abc".to_vec())
+        .header("content-range", "bytes 3-5/6")
+        .send()?;
+    assert_eq!(resp.status(), 200);
     Ok(())
 }


### PR DESCRIPTION
HTTP PATCH support https://sabre.io/dav/http-patch/
```sh
upload_offset=$(curl -I -s http://127.0.0.1:5000/file | tr -d '\r' | sed -n 's/content-length: //p')
dd skip=$upload_offset if=file status=none ibs=1 | \
  curl -X PATCH -H "X-Update-Range: append" --data-binary @- http://127.0.0.1:5000/file
```

close #335