### PR TITLE
feat: revert supporting for forbidden permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,17 +222,17 @@ Dufs supports account based access control. You can control who can do what on w
 
 ```
 dufs -a admin:admin@/:rw -a guest:guest@/
-dufs -a user:pass@/:rw,/dir1,/dir2:- -a @/
+dufs -a user:pass@/:rw,/dir1 -a @/
 ```
 
 1. Use `@` to separate the account and paths. No account means anonymous user.
 2. Use `:` to separate the username and password of the account.
 3. Use `,` to separate paths.
-4. Use path suffix `:rw`, `:ro`, `:-` to set permissions: `read-write`, `read-only`, `forbidden`. `:ro` can be omitted.
+4. Use path suffix `:rw`/`:ro` set permissions: `read-write`/`read-only`. `:ro` can be omitted.
 
 - `-a admin:admin@/:rw`: `admin` has complete permissions for all paths.
 - `-a guest:guest@/`: `guest` has read-only permissions for all paths.
-- `-a user:pass@/:rw,/dir1,/dir2:-`: `user` has read-write permissions for `/*`, has read-only permissions for `/dir1/*`, but is fordden for `/dir2/*`.
+- `-a user:pass@/:rw,/dir1`: `user` has read-write permissions for `/*`, has read-only permissions for `/dir1/*`.
 - `-a @/`: All paths is publicly accessible, everyone can view/download it.
 
 > There are no restrictions on using ':' and '@' characters in a password. For example, `user:pa:ss@1@/:rw` is valid, the password is `pa:ss@1`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -375,7 +375,7 @@ impl Server {
                 "PROPFIND" => {
                     if is_dir {
                         let access_paths =
-                            if access_paths.perm().inherit() && authorization.is_none() {
+                            if access_paths.perm().indexonly() && authorization.is_none() {
                                 // see https://github.com/sigoden/dufs/issues/229
                                 AccessPaths::new(AccessPerm::ReadOnly)
                             } else {
@@ -1230,7 +1230,7 @@ impl Server {
         access_paths: AccessPaths,
     ) -> Result<Vec<PathItem>> {
         let mut paths: Vec<PathItem> = vec![];
-        if access_paths.perm().inherit() {
+        if access_paths.perm().indexonly() {
             for name in access_paths.child_names() {
                 let entry_path = entry_path.join(name);
                 self.add_pathitem(&mut paths, base_path, &entry_path).await;

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -145,23 +145,6 @@ fn auth_readonly(
 }
 
 #[rstest]
-fn auth_forbidden(
-    #[with(&["--auth", "user:pass@/:rw,/dir1:-", "-A"])] server: TestServer,
-) -> Result<(), Error> {
-    let url = format!("{}file1", server.url());
-    let resp = fetch!(b"PUT", &url)
-        .body(b"abc".to_vec())
-        .send_with_digest_auth("user", "pass")?;
-    assert_eq!(resp.status(), 201);
-    let url = format!("{}dir1/file1", server.url());
-    let resp = fetch!(b"PUT", &url)
-        .body(b"abc".to_vec())
-        .send_with_digest_auth("user", "pass")?;
-    assert_eq!(resp.status(), 403);
-    Ok(())
-}
-
-#[rstest]
 fn auth_nest(
     #[with(&["--auth", "user:pass@/:rw", "--auth", "user2:pass2@/", "--auth", "user3:pass3@/dir1:rw", "-A"])]
     server: TestServer,


### PR DESCRIPTION
#329 supports forbidden permission, but this pr reverts it.

why revert? becase many operations are anti-pattern and difficult to process. Take `/dir1:rw,/dir1/dir2:rw` as an example.
- When deleting `/dir1`, should `/dir1/dir2` be deleted?
- When moving `/dir1`, should `/dir1/dir2` be moved?
- When zip downloading `/dir1`, do you need to include `/dir1/dir2`?
- After renaming `/dir1`, the constraints of `/dir1/dir2` fail. What should I do?
