### PR TITLE
fix: timestamp format of getlastmodified in dav xml

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1362,7 +1362,7 @@ impl PathItem {
 
     pub fn to_dav_xml(&self, prefix: &str) -> String {
         let mtime = match Utc.timestamp_millis_opt(self.mtime as i64) {
-            LocalResult::Single(v) => v.to_rfc2822(),
+            LocalResult::Single(v) => format!("{}", v.format("%a, %d %b %Y %H:%M:%S GMT")),
             _ => String::new(),
         };
         let mut href = encode_uri(&format!("{}{}", prefix, &self.name));


### PR DESCRIPTION
[RFC4918 (WebDAV)](https://datatracker.ietf.org/doc/html/rfc4918#section-15.7) requires the `getlastmodified` property to be a date *as returned* in a `Last-Modified` header. It also specifically references the `rfc1123-date` ABNF definition (though confusingly, as defined in [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-3.3.1)), which always ends in `GMT`.

Note that HTTP/1.1 clients must accept timestamps as Dufs currently generates them, but servers are not allowed to generate them, and thus by reference, WebDAV servers can't either.

Unfortunately, `chrono` doesn't have a `to_rfc1123` (or `to_rfc2616`) function, but all the parts are available via `format`.

I discovered this via error messages produced by the DAVx5 Android App: `dav4jvm : [at.bitfire.dav4jvm.HttpUtils] Couldn't parse HTTP date: Wed, 21 Feb 2024 21:03:42 +0000, ignoring`