### PR TITLE
refactor: add fixed-width numerals to date and size on file list page

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -159,12 +159,14 @@ body {
 .paths-table .cell-mtime {
   width: 120px;
   padding-left: 0.6em;
+  font-variant-numeric: tabular-nums;
 }
 
 .paths-table .cell-size {
   text-align: right;
   width: 70px;
   padding-left: 0.6em;
+  font-variant-numeric: tabular-nums;
 }
 
 .path svg {


### PR DESCRIPTION
On macOS with Chrome, numbers rendered in the default font vary in width, resulting in misalignment and a cluttered appearance on the file list page.

This pull request addresses the issue by applying the CSS property `font-variant-numeric: tabular-nums` to the date and size fields.
