### PR TITLE
feat: add index page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ List/search directory contents
 ```sh
 curl http://127.0.0.1:5000?q=Dockerfile           # search for files, similar to `find -name Dockerfile`
 curl http://127.0.0.1:5000?simple                 # output names only, similar to `ls -1`
+curl http://127.0.0.1:5000?index                 # output index only, pure read-only html
 curl http://127.0.0.1:5000?json                   # output paths in json format
 ```
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -38,6 +38,11 @@ fn use_config_file(tmpdir: TempDir, port: u16) -> Result<(), Error> {
     assert!(!text.split('\n').any(|c| c == "dir3/"));
     assert!(!text.split('\n').any(|c| c == "test.txt"));
 
+    let url = format!("http://localhost:{port}/dufs?index");
+    let resp = send_with_digest_auth(fetch!(b"GET", &url), "user", "pass")?;
+    let text: String = resp.text().unwrap();
+    assert!(text.split('\n').any(|c| c == "<!DOCTYPE html>"));
+
     let url = format!("http://localhost:{port}/dufs/dir1/upload.txt");
     let resp = send_with_digest_auth(fetch!(b"PUT", &url).body("Hello"), "user", "pass")?;
     assert_eq!(resp.status(), 201);

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -83,6 +83,19 @@ fn get_dir_simple(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
 }
 
 #[rstest]
+fn get_dir_index(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
+    let resp = reqwest::blocking::get(format!("{}?index", server.url()))?;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "text/html; charset=utf-8"
+    );
+    let text = resp.text().unwrap();
+    assert!(text.split('\n').any(|v| v == "<!DOCTYPE html>"));
+    Ok(())
+}
+
+#[rstest]
 fn head_dir_zip(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
     let resp = fetch!(b"HEAD", format!("{}?zip", server.url())).send()?;
     assert_eq!(resp.status(), 200);


### PR DESCRIPTION
Server render index page. Better for SEO or crawler maybe:

<img width="436" alt="image" src="https://github.com/sigoden/dufs/assets/10137653/364958d8-3029-4f75-9bb0-f658d3af0a49">


 My use case: https://github.com/ImranR98/Obtainium

> "HTML" (Fallback): Any other URL that returns an HTML page with links to APK files

I just want serve some apk files.