### PR TITLE
fix: head div overlap main contents when wrap

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -19,14 +19,15 @@ body {
   flex-wrap: wrap;
   align-items: center;
   padding: 0.6em 1em;
-  position: fixed;
-  width: 100%;
+  position: sticky;
+  top: 0;
   background-color: white;
 }
 
 .breadcrumb {
   font-size: 1.25em;
   padding-right: 0.6em;
+  word-break: break-all;
 }
 
 .breadcrumb>a {
@@ -108,7 +109,7 @@ body {
 }
 
 .main {
-  padding: 3.3em 1em 0;
+  padding: 0 1em;
 }
 
 .empty-folder {

--- a/assets/index.css
+++ b/assets/index.css
@@ -6,7 +6,7 @@ html {
 
 body {
   /* prevent premature breadcrumb wrapping on mobile */
-  min-width: 500px;
+  min-width: 538px;
   margin: 0;
 }
 


### PR DESCRIPTION
Before fix
![image](https://github.com/sigoden/dufs/assets/4012553/34562df1-aaf6-4639-91d0-3f2c5ae1993d)

After fix
![image](https://github.com/sigoden/dufs/assets/4012553/32e679ea-cb58-43a6-a8a9-27ca3f93ab31)
