### PR TITLE
ci: push docker image to ghcr

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,6 +160,12 @@ jobs:
         with:
           username: ${{ github.repository_owner	}}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
need secret GITHUB_TOKEN

Docker Hub is unavailable in certain locations.

Repeatedly push docker image  to ghcr.io 

code from:
https://docs.github.com/en/actions/publishing-packages/publishing-docker-images