### PR TITLE
refactor: return 400 for propfind request when depth is neither 0 nor 1

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -963,9 +963,10 @@ impl Server {
     ) -> Result<()> {
         let depth: u32 = match headers.get("depth") {
             Some(v) => match v.to_str().ok().and_then(|v| v.parse().ok()) {
-                Some(v) => v,
-                None => {
-                    status_bad_request(res, "");
+                Some(0) => 0,
+                Some(1) => 1,
+                _ => {
+                    status_bad_request(res, "Invalid depth: only 0 and 1 are allowed.");
                     return Ok(());
                 }
             },
@@ -975,7 +976,7 @@ impl Server {
             Some(v) => vec![v],
             None => vec![],
         };
-        if depth != 0 {
+        if depth > 0 {
             match self
                 .list_dir(path, &self.args.serve_path, access_paths)
                 .await

--- a/src/server.rs
+++ b/src/server.rs
@@ -976,7 +976,7 @@ impl Server {
             Some(v) => vec![v],
             None => vec![],
         };
-        if depth > 0 {
+        if depth == 1 {
             match self
                 .list_dir(path, &self.args.serve_path, access_paths)
                 .await

--- a/tests/webdav.rs
+++ b/tests/webdav.rs
@@ -41,6 +41,17 @@ fn propfind_dir_depth0(server: TestServer) -> Result<(), Error> {
 }
 
 #[rstest]
+fn propfind_dir_depth2(server: TestServer) -> Result<(), Error> {
+    let resp = fetch!(b"PROPFIND", format!("{}dir1", server.url()))
+        .header("depth", "2")
+        .send()?;
+    assert_eq!(resp.status(), 400);
+    let body = resp.text()?;
+    assert_eq!(body, "Invalid depth: only 0 and 1 are allowed.");
+    Ok(())
+}
+
+#[rstest]
 fn propfind_404(server: TestServer) -> Result<(), Error> {
     let resp = fetch!(b"PROPFIND", format!("{}404", server.url())).send()?;
     assert_eq!(resp.status(), 404);


### PR DESCRIPTION
close #402 