### PR TITLE
fix: Prevent recursive creation of parent directories

### DIFF
--- a/tests/allow.rs
+++ b/tests/allow.rs
@@ -39,7 +39,7 @@ fn allow_upload_not_exist_dir(
     #[with(&["--allow-upload"])] server: TestServer,
 ) -> Result<(), Error> {
     let resp = reqwest::blocking::get(format!("{}404/", server.url()))?;
-    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.status(), 404);
     Ok(())
 }
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -285,9 +285,9 @@ fn put_file(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
 fn put_file_create_dir(#[with(&["-A"])] server: TestServer) -> Result<(), Error> {
     let url = format!("{}xyz/file1", server.url());
     let resp = fetch!(b"PUT", &url).body(b"abc".to_vec()).send()?;
-    assert_eq!(resp.status(), 201);
+    assert_eq!(resp.status(), 409);
     let resp = reqwest::blocking::get(url)?;
-    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.status(), 404);
     Ok(())
 }
 


### PR DESCRIPTION
The specification of WebDAV (RFC4818) does not allow recursive creation of parent directories.

> During MKCOL processing, a server MUST make the Request-URI an
> internal member of its parent collection, unless the Request-URI is
> "/".  If no such ancestor exists, the method MUST fail.  When the
> MKCOL operation creates a new collection resource, all ancestors MUST
> already exist, or the method MUST fail with a 409 (Conflict) status
> code.  For example, if a request to create collection /a/b/c/d/ is
> made, and /a/b/c/ does not exist, the request must fail.[^1]

The feature to create all parent recursively when uploading, moving or copying a file has been removed and instead a check has been introduced to see if the directory exists. If not, 409 CONFLICT is returned in accordance with RFC4818.

[^1]: https://datatracker.ietf.org/doc/html/rfc4918#section-9.3