### PR TITLE
fix: special strings cause 404 problems

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -810,7 +810,7 @@ async function addFileEntries(entries, dirs) {
 function newUrl(name) {
   let url = baseUrl();
   if (!url.endsWith("/")) url += "/";
-  url += name.split("/").map(encodeURIComponent).join("/");
+  url += name.split("/").join("/");
   return url;
 }
 


### PR DESCRIPTION
This patch simply fixes an  #419  where special characters cause 404 not found.