### PR TITLE
feat: base64 index-data to avoid misencoding

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -108,7 +108,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
-  DATA = JSON.parse($indexData.innerHTML);
+  DATA = JSON.parse(atob($indexData.innerHTML));
   DIR_EMPTY_NOTE = PARAMS.q ? 'No results' : DATA.dir_exists ? 'Empty folder' : 'Folder will be created when a file is uploaded';
 
   await ready();

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,7 @@
 use crate::{args::Args, server::Response, utils::unix_now};
 
 use anyhow::{anyhow, bail, Result};
-use base64::{engine::general_purpose, Engine as _};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use headers::HeaderValue;
 use hyper::{header::WWW_AUTHENTICATE, Method};
 use indexmap::IndexMap;
@@ -287,7 +287,7 @@ pub fn www_authenticate(res: &mut Response, args: &Args) -> Result<()> {
 
 pub fn get_auth_user(authorization: &HeaderValue) -> Option<String> {
     if let Some(value) = strip_prefix(authorization.as_bytes(), b"Basic ") {
-        let value: Vec<u8> = general_purpose::STANDARD.decode(value).ok()?;
+        let value: Vec<u8> = STANDARD.decode(value).ok()?;
         let parts: Vec<&str> = std::str::from_utf8(&value).ok()?.split(':').collect();
         Some(parts[0].to_string())
     } else if let Some(value) = strip_prefix(authorization.as_bytes(), b"Digest ") {
@@ -306,7 +306,7 @@ pub fn check_auth(
     auth_pass: &str,
 ) -> Option<()> {
     if let Some(value) = strip_prefix(authorization.as_bytes(), b"Basic ") {
-        let value: Vec<u8> = general_purpose::STANDARD.decode(value).ok()?;
+        let value: Vec<u8> = STANDARD.decode(value).ok()?;
         let parts: Vec<&str> = std::str::from_utf8(&value).ok()?.split(':').collect();
 
         if parts[0] != auth_user {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use indexmap::IndexSet;
 use serde_json::Value;
 
@@ -48,7 +49,7 @@ pub fn retrieve_index_paths(content: &str) -> IndexSet<String> {
 
 #[allow(dead_code)]
 pub fn retrieve_edit_file(content: &str) -> Option<bool> {
-    let value = retrieve_json(content)?;
+    let value = retrieve_json(content).unwrap();
     let value = value.get("editable").unwrap();
     Some(value.as_bool().unwrap())
 }
@@ -73,7 +74,9 @@ pub fn retrieve_json(content: &str) -> Option<Value> {
     let end_index = line[start_content_index..].find(end_tag)?;
     let end_content_index = start_content_index + end_index;
 
-    let value = line[start_content_index..end_content_index].parse().ok()?;
+    let value = &line[start_content_index..end_content_index];
+    let value = STANDARD.decode(value).ok()?;
+    let value = serde_json::from_slice(&value).ok()?;
 
     Some(value)
 }


### PR DESCRIPTION
When passing data using html template, its JSON content is automatically escaped for HTML entities. see #419 

```
  <template id="index-data">__INDEX_DATA__</template>
```

We can use base64 to prevent such issues.