### PR TITLE
fix: garbled characters caused by atob

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -100,25 +100,6 @@ let $userBtn;
  */
 let $userName;
 
-// Parsing base64 strings with Unicode characters
-function decodeBase64WithUnicode(base64String) {
-  const binString = atob(base64String);
-  const len = binString.length;
-  const bytes = new Uint8Array(len);
-  const arr = new Uint32Array(bytes.buffer, 0, Math.floor(len / 4));
-  let i = 0;
-  for (; i < arr.length; i++) {
-    arr[i] = binString.charCodeAt(i * 4) |
-             (binString.charCodeAt(i * 4 + 1) << 8) |
-             (binString.charCodeAt(i * 4 + 2) << 16) |
-             (binString.charCodeAt(i * 4 + 3) << 24);
-  }
-  for (i = i * 4; i < len; i++) {
-    bytes[i] = binString.charCodeAt(i);
-  }
-  return new TextDecoder().decode(bytes);
-}
-
 // Produce table when window loads
 window.addEventListener("DOMContentLoaded", async () => {
   const $indexData = document.getElementById('index-data');
@@ -127,7 +108,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
-  DATA = JSON.parse(decodeBase64WithUnicode($indexData.innerHTML));
+  DATA = JSON.parse(decodeBase64($indexData.innerHTML));
   DIR_EMPTY_NOTE = PARAMS.q ? 'No results' : DATA.dir_exists ? 'Empty folder' : 'Folder will be created when a file is uploaded';
 
   await ready();
@@ -928,4 +909,23 @@ function getEncoding(contentType) {
     }
   }
   return 'utf-8';
+}
+
+// Parsing base64 strings with Unicode characters
+function decodeBase64(base64String) {
+  const binString = atob(base64String);
+  const len = binString.length;
+  const bytes = new Uint8Array(len);
+  const arr = new Uint32Array(bytes.buffer, 0, Math.floor(len / 4));
+  let i = 0;
+  for (; i < arr.length; i++) {
+    arr[i] = binString.charCodeAt(i * 4) |
+             (binString.charCodeAt(i * 4 + 1) << 8) |
+             (binString.charCodeAt(i * 4 + 2) << 16) |
+             (binString.charCodeAt(i * 4 + 3) << 24);
+  }
+  for (i = i * 4; i < len; i++) {
+    bytes[i] = binString.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
 }

--- a/assets/index.js
+++ b/assets/index.js
@@ -100,6 +100,25 @@ let $userBtn;
  */
 let $userName;
 
+// Parsing base64 strings with Unicode characters
+function decodeBase64WithUnicode(base64String) {
+  const binString = atob(base64String);
+  const len = binString.length;
+  const bytes = new Uint8Array(len);
+  const arr = new Uint32Array(bytes.buffer, 0, Math.floor(len / 4));
+  let i = 0;
+  for (; i < arr.length; i++) {
+    arr[i] = binString.charCodeAt(i * 4) |
+             (binString.charCodeAt(i * 4 + 1) << 8) |
+             (binString.charCodeAt(i * 4 + 2) << 16) |
+             (binString.charCodeAt(i * 4 + 3) << 24);
+  }
+  for (i = i * 4; i < len; i++) {
+    bytes[i] = binString.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
 // Produce table when window loads
 window.addEventListener("DOMContentLoaded", async () => {
   const $indexData = document.getElementById('index-data');
@@ -108,7 +127,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
-  DATA = JSON.parse(atob($indexData.innerHTML));
+  DATA = JSON.parse(decodeBase64WithUnicode($indexData.innerHTML));
   DIR_EMPTY_NOTE = PARAMS.q ? 'No results' : DATA.dir_exists ? 'Empty folder' : 'Folder will be created when a file is uploaded';
 
   await ready();


### PR DESCRIPTION
> Author your commit #421 solves some problems but creates some new ones. For example, when the folder is some non-ASCII form of string, it may cause garbled problems. The root cause is that the `atob` function only accept a few ASCII characters, resulting in errors parsing strings beyond the `0xff` range.
> 
> [index.js #L111](https://github.com/sigoden/dufs/blob/ca5c3d7c541f7aa89c42db312d12e634cdc41460/assets/index.js#L111)
> 
> <img alt="image" width="884" src="https://private-user-images.githubusercontent.com/47419733/350852760-0f7d4776-186a-45fc-9df9-2b7840881510.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjE2Mjg4MTksIm5iZiI6MTcyMTYyODUxOSwicGF0aCI6Ii80NzQxOTczMy8zNTA4NTI3NjAtMGY3ZDQ3NzYtMTg2YS00NWZjLTlkZjktMmI3ODQwODgxNTEwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MjIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzIyVDA2MDgzOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTM4ZDEyOWNiNGE4MjhkODEwMzBlYTExZGM0ZWNlNjhmMmI2NzQ3ZDAzODMzYjVmM2FjNzBjZGZmMzEyODRkMWQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.SfP-XMfxNWXG8D9URDzBL3o4uEAmj3rSSaP4ZDoC7Ro">

This commit fixes a problem with `atob` not parsing non-ASCII characters. The Uint32Array view is utilized to process 4 bytes at a time, potentially providing an additional performance boost when working with large amounts of data.