### PR TITLE
add special header indicating dufs and append support

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Resumable downloads
 curl -C- -o file http://127.0.0.1:5000/file
 ```
 
-Resumable uploads
+Resumable uploads (hint: you can check resumable uploads support; please see Advanced topics)
 
 ```sh
 upload_offset=$(curl -I -s http://127.0.0.1:5000/file | tr -d '\r' | sed -n 's/content-length: //p')
@@ -278,6 +278,16 @@ dufs --hidden '.*'                          # hidden dotfiles
 dufs --hidden '*/'                          # hidden all folders
 dufs --hidden '*.log,*.lock'                # hidden by exts
 dufs --hidden '*.log' --hidden '*.lock'
+```
+
+### Check Resumable Uploads Support
+
+Not all webdav server supports resumable/partial/chuncked uploads.
+
+If you (or your automatical client-side application) check the 'DAV:' header, you see the below keywords in values, you are safe to trigger a resumable upload:
+
+```
+DAV: 1, 2, 3, dufs-append
 ```
 
 ### Log Format

--- a/src/server.rs
+++ b/src/server.rs
@@ -1722,7 +1722,7 @@ fn set_webdav_headers(res: &mut Response) {
         HeaderValue::from_static("GET,HEAD,PUT,OPTIONS,DELETE,PATCH,PROPFIND,COPY,MOVE"),
     );
     res.headers_mut()
-        .insert("DAV", HeaderValue::from_static("1, 2, 3"));
+        .insert("DAV", HeaderValue::from_static("1, 2, 3, dufs-append"));
 }
 
 async fn get_content_type(path: &Path) -> Result<String> {

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -267,7 +267,7 @@ fn options_dir(server: TestServer) -> Result<(), Error> {
         resp.headers().get("allow").unwrap(),
         "GET,HEAD,PUT,OPTIONS,DELETE,PATCH,PROPFIND,COPY,MOVE"
     );
-    assert_eq!(resp.headers().get("dav").unwrap(), "1, 2, 3");
+    assert_eq!(resp.headers().get("dav").unwrap(), "1, 2, 3, dufs-append");
     Ok(())
 }
 


### PR DESCRIPTION
A special header is added.

So that some client side applications can automatically check the server is dufs and support chunk-append style updates.

Related:

https://github.com/sigoden/dufs/issues/414#issuecomment-2227144885
https://github.com/sigoden/dufs/pull/415