### PR TITLE
refactor: date formatting in cache tests

### DIFF
--- a/tests/cache.rs
+++ b/tests/cache.rs
@@ -33,7 +33,7 @@ fn get_file_with_if_modified_since_condition(
         .expect("Received no valid last modified header");
 
     let req_modified_time = (last_modified + duration_after_file_modified)
-        .format("%a, %e %b %Y %T GMT")
+        .format("%a, %d %b %Y %T GMT")
         .to_string();
 
     let resp = fetch!(b"GET", format!("{}index.html", server.url()))


### PR DESCRIPTION
This PR fixes date formatting in the tests.

Problem is, that I used "%e" formatter, which space pads the days.  
Therefore, those tests will pass on days with 2 numbers like 10.7.2024, but the tests will fail on single digit days like today 6.8.2024

This PR replaces the format with "%d" which does not space-pad the date but uses 0 pads.

ref link to the documentation: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
ref link, that 0 padding might be the way to go https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Unmodified-Since under <days>: "A 2-digit day number of the month. Examples: "04", "23"."