### PR TITLE
fix: login successed but popup `Forbidden`

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -746,7 +746,7 @@ async function saveChange() {
 async function checkAuth() {
   if (!DATA.auth) return;
   const res = await fetch(baseUrl(), {
-    method: "WRITEABLE",
+    method: "AUTH",
   });
   await assertResOK(res);
   document.querySelector(".login-btn").classList.add("hidden");

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -429,6 +429,7 @@ fn is_readonly_method(method: &Method) -> bool {
         || method == Method::OPTIONS
         || method == Method::HEAD
         || method.as_str() == "PROPFIND"
+        || method.as_str() == "AUTH"
 }
 
 fn strip_prefix<'a>(search: &'a [u8], prefix: &[u8]) -> Option<&'a [u8]> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -200,7 +200,10 @@ impl Server {
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
 
-        if method.as_str() == "WRITEABLE" {
+        if method.as_str() == "AUTH" {
+            if user.is_none() {
+                self.auth_reject(&mut res)?;
+            }
             return Ok(res);
         }
 

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -119,11 +119,11 @@ fn auth_check(
     #[with(&["--auth", "user:pass@/:rw", "--auth", "user2:pass2@/", "-A"])] server: TestServer,
 ) -> Result<(), Error> {
     let url = format!("{}index.html", server.url());
-    let resp = fetch!(b"WRITEABLE", &url).send()?;
+    let resp = fetch!(b"AUTH", &url).send()?;
     assert_eq!(resp.status(), 401);
-    let resp = send_with_digest_auth(fetch!(b"WRITEABLE", &url), "user2", "pass2")?;
-    assert_eq!(resp.status(), 403);
-    let resp = send_with_digest_auth(fetch!(b"WRITEABLE", &url), "user", "pass")?;
+    let resp = send_with_digest_auth(fetch!(b"AUTH", &url), "user", "pass")?;
+    assert_eq!(resp.status(), 200);
+    let resp = send_with_digest_auth(fetch!(b"AUTH", &url), "user2", "pass2")?;
     assert_eq!(resp.status(), 200);
     Ok(())
 }
@@ -133,11 +133,11 @@ fn auth_compact_rules(
     #[with(&["--auth", "user:pass@/:rw|user2:pass2@/", "-A"])] server: TestServer,
 ) -> Result<(), Error> {
     let url = format!("{}index.html", server.url());
-    let resp = fetch!(b"WRITEABLE", &url).send()?;
+    let resp = fetch!(b"AUTH", &url).send()?;
     assert_eq!(resp.status(), 401);
-    let resp = send_with_digest_auth(fetch!(b"WRITEABLE", &url), "user2", "pass2")?;
-    assert_eq!(resp.status(), 403);
-    let resp = send_with_digest_auth(fetch!(b"WRITEABLE", &url), "user", "pass")?;
+    let resp = send_with_digest_auth(fetch!(b"AUTH", &url), "user", "pass")?;
+    assert_eq!(resp.status(), 200);
+    let resp = send_with_digest_auth(fetch!(b"AUTH", &url), "user2", "pass2")?;
     assert_eq!(resp.status(), 200);
     Ok(())
 }


### PR DESCRIPTION
Previously, we use `WRITEABLE <path>` for auth, which requires the user to have read-write permissions. This results in a "Forbidden" popup if the user lacks read-write permissions for the specified path.

In this PR, we use `AUTH <path` for auth, which doesn't require the user to have read-write permissions.

close #436 