### PR TITLE
feat: higher perm auth path shadows lower one

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -596,7 +596,7 @@ impl Server {
             let access_paths = access_paths.clone();
             let search_paths = tokio::task::spawn_blocking(move || {
                 let mut paths: Vec<PathBuf> = vec![];
-                for dir in access_paths.child_paths(&path_buf) {
+                for dir in access_paths.entry_paths(&path_buf) {
                     let mut it = WalkDir::new(&dir).into_iter();
                     it.next();
                     while let Some(Ok(entry)) = it.next() {
@@ -1604,7 +1604,7 @@ async fn zip_dir<W: AsyncWrite + Unpin>(
     let dir_clone = dir.to_path_buf();
     let zip_paths = tokio::task::spawn_blocking(move || {
         let mut paths: Vec<PathBuf> = vec![];
-        for dir in access_paths.child_paths(&dir_clone) {
+        for dir in access_paths.entry_paths(&dir_clone) {
             let mut it = WalkDir::new(&dir).into_iter();
             it.next();
             while let Some(Ok(entry)) = it.next() {

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -336,14 +336,13 @@ fn auth_data(
 }
 
 #[rstest]
-fn auth_precedence(
-    #[with(&["--auth", "user:pass@/dir1:rw,/dir1/test.txt", "-A"])] server: TestServer,
+fn auth_shadow(
+    #[with(&["--auth", "user:pass@/:rw", "-a", "@/dir1", "-A"])] server: TestServer,
 ) -> Result<(), Error> {
     let url = format!("{}dir1/test.txt", server.url());
-    let resp = send_with_digest_auth(fetch!(b"PUT", &url).body(b"abc".to_vec()), "user", "pass")?;
-    assert_eq!(resp.status(), 403);
+    let resp = fetch!(b"PUT", &url).body(b"abc".to_vec()).send()?;
+    assert_eq!(resp.status(), 401);
 
-    let url = format!("{}dir1/file1", server.url());
     let resp = send_with_digest_auth(fetch!(b"PUT", &url).body(b"abc".to_vec()), "user", "pass")?;
     assert_eq!(resp.status(), 201);
 


### PR DESCRIPTION
In `/:rw;/path1:ro`, the `/:rw` have higher perms, it shadow `/path1:ro`, so that `/path1` is granted read and write permissions.

close #519 