### PR TITLE
Regex support in addition to glob masks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ http-body-util = "0.1"
 bytes = "1.5"
 pin-project-lite = "0.2"
 sha2 = "0.10.8"
+regex = "1"
 
 [features]
 default = ["tls"]

--- a/src/args.rs
+++ b/src/args.rs
@@ -75,7 +75,17 @@ pub fn build_cli() -> Command {
                 .long("hidden")
                 .action(ArgAction::Append)
                 .value_delimiter(',')
-                .help("Hide paths from directory listings, e.g. tmp,*.log,*.lock")
+                .help("Hide files from directory listings, by glob e.g. tmp,*.log,*.lock")
+                .value_name("value"),
+        )
+        .arg(
+            Arg::new("hidden-path")
+                .env("DUFS_HIDDEN_PATH")
+                .hide_env(true)
+                .long("hidden-path")
+                .action(ArgAction::Append)
+                .value_delimiter(',')
+                .help("Hide paths from directory listings, by regex e.g. ^tmp$,.+\\.log,\\\\hid(?:e|den)-subdir\\\\ unlike \"hidden\" processes full system paths")
                 .value_name("value"),
         )
         .arg(
@@ -273,6 +283,8 @@ pub struct Args {
     pub uri_prefix: String,
     #[serde(deserialize_with = "deserialize_string_or_vec")]
     pub hidden: Vec<String>,
+    #[serde(deserialize_with = "deserialize_string_or_vec")]
+    pub hidden_path: Vec<String>,
     #[serde(deserialize_with = "deserialize_access_control")]
     pub auth: AccessControl,
     pub allow_all: bool,

--- a/src/args.rs
+++ b/src/args.rs
@@ -85,7 +85,7 @@ pub fn build_cli() -> Command {
                 .long("hidden-path")
                 .action(ArgAction::Append)
                 .value_delimiter(',')
-                .help("Hide paths from directory listings, by regex e.g. ^tmp$,.+\\.log,\\\\hid(?:e|den)-subdir\\\\ unlike \"hidden\" processes full system paths")
+                .help("Hide paths from directory listings, by regex e.g. .+\\.log,(?i)\\\\hid(?:e|den)-Subdir\\\\ Unlike \"--hidden\" processes full system paths")
                 .value_name("value"),
         )
         .arg(

--- a/src/args.rs
+++ b/src/args.rs
@@ -360,6 +360,17 @@ impl Args {
                 .collect();
         }
 
+        if let Some(hidden_path) = matches.get_many::<String>("hidden-path") {
+            args.hidden_path = hidden_path.cloned().collect();
+        } else {
+            let mut hidden_path = vec![];
+            std::mem::swap(&mut args.hidden_path, &mut hidden_path);
+            args.hidden_path = hidden_path
+                .into_iter()
+                .flat_map(|v| v.split(',').map(|v| v.to_string()).collect::<Vec<String>>())
+                .collect();
+        }
+
         if !args.enable_cors {
             args.enable_cors = matches.get_flag("enable-cors");
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,6 +52,14 @@ pub fn try_get_file_name(path: &Path) -> Result<&str> {
         .ok_or_else(|| anyhow!("Failed to get file name of `{}`", path.display()))
 }
 
+pub fn regx(pattern: &str, target: &str) -> bool {
+    let rex = match regex::Regex::new(pattern) {
+        Ok(rex) => rex,
+        Err(_) => return false,
+    };
+    rex.is_match(target)
+}
+
 pub fn glob(pattern: &str, target: &str) -> bool {
     let pat = match ::glob::Pattern::new(pattern) {
         Ok(pat) => pat,


### PR DESCRIPTION
Hi! We discussed last time that you can't break compatibility with existing configurations. I completely agree with this and prepared a patch that adds regular expression filters in addition to glob mask filters. Using regular expressions it is easy to implement, for example, a hidden root folder or a hidden folder anywhere in the file system, etc. I don't know if this proposal will be accepted in your project, but on my server it works exactly like this :))