### PR TITLE
feat: add HSTS support

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -215,14 +215,6 @@ pub fn build_cli() -> Command {
                 .value_name("level")
                 .help("Set zip compress level [default: low]")
         )
-		.arg(
-            Arg::new("enable-hsts")
-                .env("DUFS_ENABLE_HSTS")
-				.hide_env(true) 
-                .long("enable-hsts")
-                .action(ArgAction::SetTrue)
-                .help("Enable HTTP Strict Transport Security (HSTS) headers"),
-        )
         .arg(
             Arg::new("completions")
                 .long("completions")
@@ -252,6 +244,14 @@ pub fn build_cli() -> Command {
                 .value_name("path")
                 .value_parser(value_parser!(PathBuf))
                 .help("Path to the SSL/TLS certificate's private key"),
+        )
+		.arg(
+            Arg::new("enable-hsts")
+                .env("DUFS_ENABLE_HSTS")
+				.hide_env(true) 
+                .long("enable-hsts")
+                .action(ArgAction::SetTrue)
+                .help("Enable HTTP Strict Transport Security (HSTS) headers"),
         );
 
     app

--- a/src/args.rs
+++ b/src/args.rs
@@ -215,6 +215,14 @@ pub fn build_cli() -> Command {
                 .value_name("level")
                 .help("Set zip compress level [default: low]")
         )
+		.arg(
+            Arg::new("enable-hsts")
+                .env("DUFS_ENABLE_HSTS")
+				.hide_env(true) 
+                .long("enable-hsts")
+                .action(ArgAction::SetTrue)
+                .help("Enable HTTP Strict Transport Security (HSTS) headers"),
+        )
         .arg(
             Arg::new("completions")
                 .long("completions")
@@ -222,6 +230,8 @@ pub fn build_cli() -> Command {
                 .value_parser(value_parser!(Shell))
                 .help("Print shell completion script for <shell>"),
         );
+
+
 
     #[cfg(feature = "tls")]
     let app = app
@@ -291,6 +301,7 @@ pub struct Args {
     pub http_logger: HttpLogger,
     pub log_file: Option<PathBuf>,
     pub compress: Compress,
+	pub enable_hsts: bool,
     pub tls_cert: Option<PathBuf>,
     pub tls_key: Option<PathBuf>,
 }
@@ -404,6 +415,10 @@ impl Args {
 
         if let Some(log_file) = matches.get_one::<PathBuf>("log-file") {
             args.log_file = Some(log_file.clone());
+        }
+		
+		if !args.enable_hsts {
+            args.enable_hsts = matches.get_flag("enable-hsts");
         }
 
         if let Some(compress) = matches.get_one::<Compress>("compress") {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -296,6 +296,12 @@ impl AccessPerm {
 }
 
 pub fn www_authenticate(res: &mut Response, args: &Args) -> Result<()> {
+	if args.enable_hsts {
+		res.headers_mut().insert(
+			"strict-transport-security",
+			HeaderValue::from_static("max-age=31536000"),
+			);
+	}
     if args.auth.use_hashed_password {
         let basic = HeaderValue::from_str(&format!("Basic realm=\"{}\"", REALM))?;
         res.headers_mut().insert(WWW_AUTHENTICATE, basic);

--- a/src/server.rs
+++ b/src/server.rs
@@ -778,6 +778,12 @@ impl Server {
                 "x-content-type-options",
                 HeaderValue::from_static("nosniff"),
             );
+		if self.args.enable_hsts {
+			res.headers_mut().insert(
+				"strict-transport-security",
+				HeaderValue::from_static("max-age=31536000"),
+			);
+		}
             Ok(true)
         } else if req_path == HEALTH_CHECK_PATH {
             res.headers_mut()
@@ -1239,6 +1245,12 @@ impl Server {
             "x-content-type-options",
             HeaderValue::from_static("nosniff"),
         );
+		if self.args.enable_hsts {
+			res.headers_mut().insert(
+				"strict-transport-security",
+				HeaderValue::from_static("max-age=31536000"),
+			);
+		}
         if head_only {
             return Ok(());
         }


### PR DESCRIPTION
An optional HSTS (HTTP Strict Transport Security) header has been added to the auth and internal response. This header can be enabled with the --enable-hsts flag or enable-hsts: true in the YAML config.

Browser HSTS enforcement duration is set to 1 year.