### PR TITLE
Maximum archive size and `--follow-symlinks` flag

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -881,8 +881,8 @@ function padZero(value, size) {
 }
 
 function formatDirSize(size) {
-  const unit = file.size === 1 ? "item" : "items";
-  const num = size >= MAX_SUBPATHS_COUNT ? `>${MAX_SUBPATHS_COUNT - 1}` : `${file.size}`;
+  const unit = size === 1 ? "item" : "items";
+  const num = size >= MAX_SUBPATHS_COUNT ? `>${MAX_SUBPATHS_COUNT - 1}` : `${size}`;
   return ` ${num} ${unit}`;
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -148,6 +148,16 @@ pub fn build_cli() -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Allow download folders as archive file"),
         )
+
+        .arg(
+            Arg::new("max-archive-size")
+                .env("DUFS_MAX_ARCHIVE_SIZE")
+				.hide_env(true)
+                .long("max-archive-size")
+                .value_parser(value_parser!(u64))
+                .help("Maximum (uncompressed) total size in bytes of files/directories to be archived [default: no maximum]")
+                .value_name("max_archive_size"),
+        )
         .arg(
             Arg::new("follow-symlinks")
                 .env("DUFS_FOLLOW_SYMLINKS")
@@ -289,6 +299,7 @@ pub struct Args {
     pub allow_search: bool,
     pub allow_symlink: bool,
     pub allow_archive: bool,
+    pub max_archive_size: Option<u64>,
     pub follow_symlinks: bool,
     pub render_index: bool,
     pub render_spa: bool,
@@ -392,6 +403,10 @@ impl Args {
         }
         if !args.render_index {
             args.render_index = matches.get_flag("render-index");
+        }
+
+        if let Some(max_archive_size) = matches.get_one::<u64>("max-archive-size") {
+            args.max_archive_size = Some(*max_archive_size);
         }
 
         if !args.render_try_index {

--- a/src/args.rs
+++ b/src/args.rs
@@ -149,6 +149,14 @@ pub fn build_cli() -> Command {
                 .help("Allow download folders as archive file"),
         )
         .arg(
+            Arg::new("follow-symlinks")
+                .env("DUFS_FOLLOW_SYMLINKS")
+				.hide_env(true)
+                .long("follow-symlinks")
+                .action(ArgAction::SetTrue)
+                .help("When searching files/folders or when archiving folders, also search/archive symlinked targets"),
+        )
+        .arg(
             Arg::new("enable-cors")
                 .env("DUFS_ENABLE_CORS")
 				.hide_env(true)
@@ -281,6 +289,7 @@ pub struct Args {
     pub allow_search: bool,
     pub allow_symlink: bool,
     pub allow_archive: bool,
+    pub follow_symlinks: bool,
     pub render_index: bool,
     pub render_spa: bool,
     pub render_try_index: bool,
@@ -371,6 +380,9 @@ impl Args {
         }
         if !args.allow_search {
             args.allow_search = allow_all || matches.get_flag("allow-search");
+        }
+        if !args.follow_symlinks {
+            args.follow_symlinks = matches.get_flag("follow-symlinks");
         }
         if !args.allow_symlink {
             args.allow_symlink = allow_all || matches.get_flag("allow-symlink");


### PR DESCRIPTION
This PR adds the following changes:
* A `--follow-symlinks` flag has been added. When set (`false` by default), searching and archiving will follow symlinks (i.e., include targets in searches/ZIP files).
* A `--max-archive-size` flag has been added with which a maximum byte size for archives can be set. The purpose of this is to prevent huge downloads, which could use up more resources than desired (bandwidth/CPU if compression is enabled).
   * Implementing this feature itself was pretty straightforward, but I had to refactor the `handle_zip_files` function a little to make it possible to display an error message to the user when the archive turns out too big. 
* A small bug has been fixed that lead to an incorrect item count being displayed for directories.