### PR TITLE
feat: support authentication via token (#522)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,7 @@ dependencies = [
  "futures-util",
  "glob",
  "headers",
+ "hex",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -527,6 +528,7 @@ dependencies = [
  "pin-project-lite",
  "port_check",
  "predicates",
+ "rand 0.9.1",
  "regex",
  "reqwest",
  "rstest",
@@ -1444,7 +1446,7 @@ checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1498,13 +1500,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy",
 ]
 
 [[package]]
@@ -2251,7 +2252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ http-body-util = "0.1"
 bytes = "1.5"
 pin-project-lite = "0.2"
 sha2 = "0.10.8"
+rand = "0.9.1"
+hex = "0.4.3"
 
 [features]
 default = ["tls"]

--- a/assets/index.js
+++ b/assets/index.js
@@ -18,6 +18,7 @@
  * @property {boolean} allow_archive
  * @property {boolean} auth
  * @property {string} user
+ * @property {string} token
  * @property {boolean} dir_exists
  * @property {string} editable
  */
@@ -417,12 +418,13 @@ function renderPathsTableHead() {
  */
 function renderPathsTableBody() {
   if (DATA.paths && DATA.paths.length > 0) {
+    const token = DATA.token || "";
     const len = DATA.paths.length;
     if (len > 0) {
       $pathsTable.classList.remove("hidden");
     }
     for (let i = 0; i < len; i++) {
-      addPath(DATA.paths[i], i);
+      addPath(DATA.paths[i], i, token);
     }
   } else {
     $emptyFolder.textContent = DIR_EMPTY_NOTE;
@@ -434,8 +436,9 @@ function renderPathsTableBody() {
  * Add pathitem
  * @param {PathItem} file
  * @param {number} index
+ * @param {string} token
  */
-function addPath(file, index) {
+function addPath(file, index, token) {
   const encodedName = encodedStr(file.name);
   let url = newUrl(file.name);
   let actionDelete = "";
@@ -449,27 +452,27 @@ function addPath(file, index) {
     if (DATA.allow_archive) {
       actionDownload = `
       <div class="action-btn">
-        <a href="${url}?zip" title="Download folder as a .zip file">${ICONS.download}</a>
+        <a href="${url}?token=${token}&zip" title="Download folder as a .zip file">${ICONS.download}</a>
       </div>`;
     }
   } else {
     actionDownload = `
     <div class="action-btn" >
-      <a href="${url}" title="Download file" download>${ICONS.download}</a>
+      <a href="${url}?token=${token}" title="Download file" download>${ICONS.download}</a>
     </div>`;
   }
   if (DATA.allow_delete) {
     if (DATA.allow_upload) {
       actionMove = `<div onclick="movePath(${index})" class="action-btn" id="moveBtn${index}" title="Move to new path">${ICONS.move}</div>`;
       if (!isDir) {
-        actionEdit = `<a class="action-btn" title="Edit file" target="_blank" href="${url}?edit">${ICONS.edit}</a>`;
+        actionEdit = `<a class="action-btn" title="Edit file" target="_blank" href="${url}?token=${token}&edit">${ICONS.edit}</a>`;
       }
     }
     actionDelete = `
     <div onclick="deletePath(${index})" class="action-btn" id="deleteBtn${index}" title="Delete">${ICONS.delete}</div>`;
   }
   if (!actionEdit && !isDir) {
-    actionView = `<a class="action-btn" title="View file" target="_blank" href="${url}?view">${ICONS.view}</a>`;
+    actionView = `<a class="action-btn" title="View file" target="_blank" href="${url}?token=${token}&view">${ICONS.view}</a>`;
   }
   let actionCell = `
   <td class="cell-actions">
@@ -488,7 +491,7 @@ function addPath(file, index) {
     ${getPathSvg(file.path_type)}
   </td>
   <td class="path cell-name">
-    <a href="${url}" ${isDir ? "" : `target="_blank"`}>${encodedName}</a>
+    <a href="${url}?token=${token}" ${isDir ? "" : `target="_blank"`}>${encodedName}</a>
   </td>
   <td class="cell-mtime">${formatMtime(file.mtime)}</td>
   <td class="cell-size">${sizeDisplay}</td>
@@ -530,7 +533,7 @@ async function setupAuth() {
     $loginBtn.addEventListener("click", async () => {
       try {
         await checkAuth();
-      } catch {}
+      } catch { }
       location.reload();
     });
   }


### PR DESCRIPTION
This PR introduces a **token-based access mechanism** to support authenticated access to resource files via URL parameters. With this enhancement, clients can include a token in the URL to bypass unauthorized status codes and access protected resources directly.

### Example

Resource access URLs are transformed as follows:

```
http://192.168.1.2:5000/a.txt
==>
http://192.168.1.2:5000/a.txt?token=45744af16aec4611dacf91f9b35de8a32ce96f82308e8af9e8052da7f826c78e
```


### Token Design
- Each token is a **32-byte random value**.
- The **last 8 bytes are XORed with the current timestamp** to reduce collision probability.
- Tokens are encapsulated in a `UserToken` struct:   [`auth.rs#L50`](https://github.com/52funny/dufs/blob/f26e22e726bc9cf624621a937e9562e0800d00a1/src/auth.rs#L50)
- The `UserToken` is currently a wrapper around a `String`, making it easy to switch to other token formats (e.g., JWT) in the future.

### Access Policy
The access flow is defined as follows: [`auth.rs#L160`](https://github.com/52funny/dufs/blob/f26e22e726bc9cf624621a937e9562e0800d00a1/src/auth.rs#L160)
 - If a valid `token` is present in the URL, access is granted.
 - If the token is **invalid**, the server falls back to the `WWW-Authenticate` header.
 - If both methods fail, the request is **denied**.