### PR TITLE
chore: removes clippy warning with rust 1.89

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ pub fn encode_uri(v: &str) -> String {
     parts.join("/")
 }
 
-pub fn decode_uri(v: &str) -> Option<Cow<str>> {
+pub fn decode_uri(v: &str) -> Option<Cow<'_, str>> {
     percent_encoding::percent_decode(v.as_bytes())
         .decode_utf8()
         .ok()


### PR DESCRIPTION
Rust introduced with 1.89 a new warning when Lifetime elison in function signature happens. [1]

This removes the code which generate those warning.

[1] https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint