### PR TITLE
disable iframe sandboxing to fix PDF embedding

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -656,7 +656,7 @@ async function setupEditorPage() {
     const url = baseUrl();
     const ext = extName(baseName(url));
     if (IFRAME_FORMATS.find(v => v === ext)) {
-      $notEditable.insertAdjacentHTML("afterend", `<iframe src="${url}" sandbox width="100%" height="${window.innerHeight - 100}px"></iframe>`);
+      $notEditable.insertAdjacentHTML("afterend", `<iframe src="${url}" width="100%" height="${window.innerHeight - 100}px"></iframe>`);
     } else {
       $notEditable.classList.remove("hidden");
       $notEditable.textContent = "Cannot edit because file is too large or binary.";


### PR DESCRIPTION
Applying the the `sandbox` attribute to an iFrame but with an empty value applies all sandboxing restrictions to the iFrame, and this prevents the PDF preview on Edit/View (`?edit`/`?view`) pages from working (this problem was reported as https://github.com/sigoden/dufs/issues/648).