### PR TITLE
fix: skip plain directory listing on HEAD requests

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -574,6 +574,11 @@ impl Server {
         access_paths: AccessPaths,
         res: &mut Response,
     ) -> Result<()> {
+        if head_only && query_params.is_empty() {
+            self.send_index_head(res);
+            return Ok(());
+        }
+
         let mut paths = vec![];
         if exist {
             paths = match self.list_dir(path, path, access_paths.clone()).await {
@@ -1316,6 +1321,17 @@ impl Server {
         }
         *res.body_mut() = body_full(output);
         Ok(())
+    }
+
+    fn send_index_head(&self, res: &mut Response) {
+        res.headers_mut()
+            .typed_insert(ContentType::from(mime_guess::mime::TEXT_HTML_UTF_8));
+        res.headers_mut()
+            .typed_insert(CacheControl::new().with_no_cache());
+        res.headers_mut().insert(
+            "x-content-type-options",
+            HeaderValue::from_static("nosniff"),
+        );
     }
 
     fn auth_reject(&self, res: &mut Response) -> Result<()> {

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -21,6 +21,7 @@ fn head_dir(server: TestServer) -> Result<(), Error> {
         resp.headers().get("content-type").unwrap(),
         "text/html; charset=utf-8"
     );
+    assert!(!resp.headers().contains_key("content-length"));
     assert_eq!(resp.text()?, "");
     Ok(())
 }


### PR DESCRIPTION
Related to #682.

#686 improved exact-path metadata lookup for files via `?json`, but plain directory `HEAD` requests still take the full directory listing path. This PR does not add a new metadata API. It only avoids unnecessary work for the existing plain directory `HEAD` case.