### PR TITLE
Feature: confirm on exit while uploading

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -106,6 +106,17 @@ let $logoutBtn;
  */
 let $userName;
 
+// manage unload event to prevent leaving with uploads in progress
+// TBD: brave refuses to show the box 
+const beforeUnloadHandler = (event) => {
+  if (Uploader.queues.length > 0 || Uploader.runnings > 0) {
+    event.preventDefault();
+    const warningMessage = 'Uploads are in progress. Are you sure you want to leave?';
+    event.returnValue = warningMessage;
+    return warningMessage; // for some browsers
+  }
+};
+
 // Produce table when window loads
 window.addEventListener("DOMContentLoaded", async () => {
   const $indexData = document.getElementById('index-data');
@@ -130,6 +141,8 @@ async function ready() {
   $loginBtn = document.querySelector(".login-btn");
   $logoutBtn = document.querySelector(".logout-btn");
   $userName = document.querySelector(".user-name");
+
+  window.addEventListener('beforeunload', beforeUnloadHandler);
 
   addBreadcrumb(DATA.href, DATA.uri_prefix);
 

--- a/assets/index.js
+++ b/assets/index.js
@@ -107,13 +107,11 @@ let $logoutBtn;
 let $userName;
 
 // manage unload event to prevent leaving with uploads in progress
-// TBD: brave refuses to show the box 
 const beforeUnloadHandler = (event) => {
   if (Uploader.queues.length > 0 || Uploader.runnings > 0) {
     event.preventDefault();
-    const warningMessage = 'Uploads are in progress. Are you sure you want to leave?';
-    event.returnValue = warningMessage;
-    return warningMessage; // for some browsers
+    event.returnValue = '';
+    return ''; // for some browsers
   }
 };
 


### PR DESCRIPTION
Hey, we have noticed, that there is no confirmation when closing the tab and an upload is not finished. This can result in an unnecessary cancel of the upload. Can be quite frustrating when you are at 90% out of 6GB. :)

**Solution**
Added the event listener for it. 

**Tested on:**
- Edge
- Chrome
- Safari
- Brave(MacOS)
- Brave on windows does not show it at all. But this is rather their implementation not reacting to the event. I'll open an issue there to see what's up, but in the end the implementation should not differ.
- Maybe you have firefox to test it on.

@sigoden Lmk what you think. Hope this gets merged, because we would really need it. :)

***
<img width="449" height="147" alt="image" src="https://github.com/user-attachments/assets/8d9aa332-8527-4d31-a961-b77916628662" />
Here an example of the displayed box. Tried adding a custom message, but browsers seem to ignore it for security reasons.