### PR TITLE
Fix: safari bug downloadspeed

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -260,6 +260,8 @@ class Uploader {
 
   progress(event) {
     const now = Date.now();
+    const elapsed = now - this.lastUptime;
+    if (elapsed < 300) return; // throttle update for safari
     const speed = (event.loaded - this.uploaded) / (now - this.lastUptime) * 1000;
     const [speedValue, speedUnit] = formatFileSize(speed);
     const speedText = `${speedValue} ${speedUnit}/s`;

--- a/assets/index.js
+++ b/assets/index.js
@@ -262,7 +262,7 @@ class Uploader {
     const now = Date.now();
     const elapsed = now - this.lastUptime;
     if (elapsed < 300) return; // throttle update for safari
-    const speed = (event.loaded - this.uploaded) / (now - this.lastUptime) * 1000;
+    const speed = (event.loaded - this.uploaded) / (elapsed) * 1000;
     const [speedValue, speedUnit] = formatFileSize(speed);
     const speedText = `${speedValue} ${speedUnit}/s`;
     const progress = formatPercent(((event.loaded + this.uploadOffset) / this.file.size) * 100);


### PR DESCRIPTION
On **Safari**, the download speed was updating too fast. Moreover, the speed was not readable, and you could see `NaN and undefined`.

<details>
<summary>Some pictures before the fix</summary>
<br>
<img width="637" height="205" alt="Screenshot 2026-04-26 at 12 52 23" src="https://github.com/user-attachments/assets/0f5ad935-e523-4102-8eef-de99a0a67c29" />
<img width="518" height="994" alt="Screenshot 2026-04-26 at 11 52 39" src="https://github.com/user-attachments/assets/69e2d06b-7e08-47ef-a524-0fcb7c0c1c2b" />
<img width="521" height="1017" alt="Screenshot 2026-04-26 at 11 48 35" src="https://github.com/user-attachments/assets/4f435101-418d-4e89-81c5-342d3f7e1ea9" />

Same upload on Brave:
<img width="669" height="950" alt="Screenshot 2026-04-26 at 11 56 48" src="https://github.com/user-attachments/assets/87b40a69-e439-4316-b963-e56cb84f1c5b" />


</details>

***

**From what I gathered:**
- Safari fires `progress` events very rapidly
- Two events fire within the same millisecond
- `Date.now()` returns the same value for both, because of 1ms resolution
- `elapsed = 0` -> division by zero -> Infinity -> NaN cascade

Brave/Chrome have sub-millisecond timer resolution, so two events within the same millisecond still return different `Date.now()` values, and `elapsed` is never `0`.

Here is a video of how it looked after the guard.

https://github.com/user-attachments/assets/182f782f-c52c-4f10-8803-b5620edd9a76

So a "throttle" was necessary, hence the `elapsed < 300`

https://github.com/user-attachments/assets/487a01c0-0f42-4de0-a51a-a8e84c8f60d1

