### PR TITLE
fix: avoid directory listing work for plain HEAD requests

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -578,6 +578,11 @@ impl Server {
         access_paths: AccessPaths,
         res: &mut Response,
     ) -> Result<()> {
+        if head_only && query_params.is_empty() {
+            self.send_index_head(res);
+            return Ok(());
+        }
+
         let mut paths = vec![];
         if exist {
             paths = match self.list_dir(path, path, access_paths.clone()).await {
@@ -1342,6 +1347,17 @@ impl Server {
         }
         *res.body_mut() = body_full(output);
         Ok(())
+    }
+
+    fn send_index_head(&self, res: &mut Response) {
+        res.headers_mut()
+            .typed_insert(ContentType::from(mime_guess::mime::TEXT_HTML_UTF_8));
+        res.headers_mut()
+            .typed_insert(CacheControl::new().with_no_cache());
+        res.headers_mut().insert(
+            "x-content-type-options",
+            HeaderValue::from_static("nosniff"),
+        );
     }
 
     fn auth_reject(&self, res: &mut Response) -> Result<()> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -206,7 +206,7 @@ impl Server {
             (x, Some(y)) => (x, y),
         };
 
-        if detect_noscript(&user_agent) {
+        if method == Method::GET && detect_noscript(&user_agent) {
             query_params.insert("noscript".to_string(), String::new());
         }
 

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -21,6 +21,7 @@ fn head_dir(server: TestServer) -> Result<(), Error> {
         resp.headers().get("content-type").unwrap(),
         "text/html; charset=utf-8"
     );
+    assert!(!resp.headers().contains_key("content-length"));
     assert_eq!(resp.text()?, "");
     Ok(())
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -15,7 +15,9 @@ fn get_dir(server: TestServer) -> Result<(), Error> {
 
 #[rstest]
 fn head_dir(server: TestServer) -> Result<(), Error> {
-    let resp = fetch!(b"HEAD", server.url()).send()?;
+    let resp = fetch!(b"HEAD", server.url())
+        .header("user-agent", "curl/8.7.1")
+        .send()?;
     assert_eq!(resp.status(), 200);
     assert_eq!(
         resp.headers().get("content-type").unwrap(),


### PR DESCRIPTION
 Supersedes #687.

Today, a plain directory `HEAD` still goes through almost the full directory-listing path and only skips the body at the end. That means `HEAD` can still pay nearly the same backend cost as `GET`, even when the caller only wants headers / an existence check. In practice, `HEAD` can be used as a lightweight directory-existence probe, where only the response status and headers matter.

On slow or remote storage, that difference is noticeable. In my Samba-backed setup, a `HEAD` request to a 470-entry directory takes about **49.7s** before this change and about **0.14s** after it:

 ```sh
 # before
 $ time curl -I http://localhost:5000/large/or/slow/directory/
 HTTP/1.1 200 OK
 content-type: text/html; charset=utf-8
 content-length: 58977
 cache-control: no-cache
 x-content-type-options: nosniff

 curl -I  49.673 total

 # after
 $ time curl -I http://localhost:5000/large/or/slow/directory/
 HTTP/1.1 200 OK
 content-type: text/html; charset=utf-8
 cache-control: no-cache
 x-content-type-options: nosniff

 curl -I  0.142 total
```

The previous PR missed one detail: curl-like clients are detected as noscript, so plain directory HEAD could still fall back to the listing path. This version limits noscript detection to GET, which preserves existing GET behavior and lets plain directory HEAD return early.

No new API is added, and this does not change directory GET, ?json, or WebDAV behavior.

References:

 - supersedes #687
 - related context: #682