### PR TITLE
fix: liblzma dynamic linking issues on MacOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,7 @@ dependencies = [
  "if-addrs",
  "indexmap",
  "lazy_static",
+ "liblzma",
  "log",
  "md5",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 async_zip = { version = "0.0.18", default-features = false, features = ["deflate", "bzip2", "xz", "chrono", "tokio"] }
+liblzma = { version = "0.4", features = ["static"] } # avoid dynamic linking issues on MacOS
 headers = "0.4"
 mime_guess = "2.0"
 if-addrs = "0.15"


### PR DESCRIPTION
This issue may have existed since the first released version, and users who don't use brew and directly download binaries are really rare.

I don't have this issue locally on my macOS because my `which pkg-config` is `/opt/local/bin/pkg-config`, whereas on GitHub Actions' macOS, it's under Homebrew. 

Close #711 