### PR TITLE
fix: 修复 v0.46.0 文件上传 404 错误（非存在路径跳过符号链接检查）

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -273,7 +273,9 @@ impl Server {
         let render_spa = self.args.render_spa;
         let render_try_index = self.args.render_try_index;
 
-        if self.guard_root_contained(path).await {
+        // Skip symlink guard for non-existent paths (matches v0.45.0 behavior)
+        // This allows uploads to directories that don't exist yet
+        if !is_miss && self.guard_root_contained(path).await {
             self.handle_not_found(&query_params, headers, head_only, &mut res)
                 .await?;
             return Ok(res);


### PR DESCRIPTION
## 问题描述

PR #670 (commit a118c13) 引入了 `guard_root_contained` 方法，用于防止符号链接攻击。但该方法对所有请求无条件执行检查，包括尚不存在的路径，导致文件/文件夹上传功能失效。

### 复现步骤

1. 使用 `--allow-all` 启动 dufs v0.46.0
2. 通过 Web UI 上传文件到新目录
3. 上传失败，返回 404 错误

### 根因分析

`guard_root_contained` 方法只检查**直接父目录**。当上传到新目录时：

1. 路径 `/a/b/c/file.txt` 不存在
2. 检查父目录 `/a/b/c` — 不存在
3. `fs::canonicalize` 失败
4. 守卫返回 `true` → 返回 404

在 v0.45.0 中，符号链接检查会在路径不存在时跳过（`!is_miss` 检查），允许上传操作创建新目录。

## 修复方案

在 `guard_root_contained` 调用前添加 `!is_miss` 检查：

```rust
// 修复前（v0.46.0 - 有 bug）
if self.guard_root_contained(path).await {

// 修复后（恢复 v0.45.0 行为）
if !is_miss && self.guard_root_contained(path).await {
```

修复效果

- ✅ 允许上传文件到新目录
- ✅ 允许上传嵌套文件夹（自动创建中间目录）
- ✅ 允许 MKCOL 创建新目录
- ✅ 对已存在路径仍执行符号链接安全检查