### PR TITLE
fix: require path separator boundary when stripping --path-prefix

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1439,8 +1439,11 @@ impl Server {
         if path_prefix.is_empty() {
             return Some(new_path);
         }
+        if new_path == path_prefix {
+            return Some(String::new());
+        }
         new_path
-            .strip_prefix(path_prefix.trim_start_matches('/'))
+            .strip_prefix(&format!("{path_prefix}/"))
             .map(|v| v.trim_matches('/').to_string())
     }
 

--- a/tests/args.rs
+++ b/tests/args.rs
@@ -22,6 +22,24 @@ fn path_prefix_file(#[with(&["--path-prefix", "xyz"])] server: TestServer) -> Re
 }
 
 #[rstest]
+fn path_prefix_reject_same_component(
+    #[with(&["--path-prefix", "xyz"])] server: TestServer,
+) -> Result<(), Error> {
+    let resp = reqwest::blocking::get(format!("{}xyzpublic.txt", server.url()))?;
+    assert_eq!(resp.status(), 400);
+    Ok(())
+}
+
+#[rstest]
+fn path_prefix_reject_extra_component_text(
+    #[with(&["--path-prefix", "xyz"])] server: TestServer,
+) -> Result<(), Error> {
+    let resp = reqwest::blocking::get(format!("{}xyzevil/public.txt", server.url()))?;
+    assert_eq!(resp.status(), 400);
+    Ok(())
+}
+
+#[rstest]
 fn path_prefix_propfind(
     #[with(&["--path-prefix", "xyz"])] server: TestServer,
 ) -> Result<(), Error> {


### PR DESCRIPTION
The resolve_path function used str::strip_prefix which accepted same-component prefix matches (e.g. prefix "pfx" matched both "/pfx/file" and "/pfxfile"). Now requires the prefix to be followed by "/" or be an exact match to serve the root.