### PR TITLE
fix: keep directories
  on top when sorting in descending order

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1261,7 +1261,9 @@ impl Server {
                 .map(|v| v == "desc")
                 .unwrap_or_default()
             {
-                paths.reverse()
+                paths.reverse();
+                // keep directories grouped on top, in reverse order within the group
+                paths.sort_by_key(|v| !v.path_type.is_dir());
             }
         } else {
             paths.sort_by(|v1, v2| v1.sort_by_name(v2))

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -4,15 +4,29 @@ mod utils;
 use fixtures::{server, Error, TestServer};
 use rstest::rstest;
 
+fn assert_dirs_first_and_reversed_within_groups(paths_asc: &[String], paths_desc: &[String]) {
+    let dir_count = paths_asc.iter().filter(|v| v.ends_with('/')).count();
+    // directories are grouped on top for both orders
+    assert!(paths_asc[..dir_count].iter().all(|v| v.ends_with('/')));
+    assert!(paths_desc[..dir_count].iter().all(|v| v.ends_with('/')));
+    // within each group, desc is the reverse of asc
+    let mut expected: Vec<String> = paths_asc[..dir_count].iter().rev().cloned().collect();
+    expected.extend(paths_asc[dir_count..].iter().rev().cloned());
+    assert_eq!(paths_desc, expected);
+}
+
 #[rstest]
 fn ls_dir_sort_by_name(server: TestServer) -> Result<(), Error> {
     let url = server.url();
     let resp = reqwest::blocking::get(format!("{url}?sort=name&order=asc"))?;
-    let paths1 = self::utils::retrieve_index_paths(&resp.text()?);
+    let paths1: Vec<String> = self::utils::retrieve_index_paths(&resp.text()?)
+        .into_iter()
+        .collect();
     let resp = reqwest::blocking::get(format!("{url}?sort=name&order=desc"))?;
-    let mut paths2 = self::utils::retrieve_index_paths(&resp.text()?);
-    paths2.reverse();
-    assert_eq!(paths1, paths2);
+    let paths2: Vec<String> = self::utils::retrieve_index_paths(&resp.text()?)
+        .into_iter()
+        .collect();
+    assert_dirs_first_and_reversed_within_groups(&paths1, &paths2);
     Ok(())
 }
 
@@ -20,10 +34,13 @@ fn ls_dir_sort_by_name(server: TestServer) -> Result<(), Error> {
 fn search_dir_sort_by_name(server: TestServer) -> Result<(), Error> {
     let url = server.url();
     let resp = reqwest::blocking::get(format!("{url}?q=test.html&sort=name&order=asc"))?;
-    let paths1 = self::utils::retrieve_index_paths(&resp.text()?);
+    let paths1: Vec<String> = self::utils::retrieve_index_paths(&resp.text()?)
+        .into_iter()
+        .collect();
     let resp = reqwest::blocking::get(format!("{url}?q=test.html&sort=name&order=desc"))?;
-    let mut paths2 = self::utils::retrieve_index_paths(&resp.text()?);
-    paths2.reverse();
-    assert_eq!(paths1, paths2);
+    let paths2: Vec<String> = self::utils::retrieve_index_paths(&resp.text()?)
+        .into_iter()
+        .collect();
+    assert_dirs_first_and_reversed_within_groups(&paths1, &paths2);
     Ok(())
 }


### PR DESCRIPTION
## Problem

The directory listing groups directories on top: all three comparators
(`sort_by_name`, `sort_by_mtime`, `sort_by_size`) compare `path_type` first.
But when `order=desc` is requested, the handler reverses the whole vector
(`paths.reverse()`), which also undoes the grouping — directories sink to the
bottom of the page.

Repro: open any directory containing both subdirectories and files and click
"Last Modified" or "Size" (or `GET /?sort=mtime&order=desc`): files are listed
first, directories end up at the bottom.

## Fix

After the reverse, re-group directories on top with a stable sort:

```rust
paths.sort_by_key(|v| !v.path_type.is_dir());
```

Being stable, it preserves the requested descending order within each group
(directories among themselves, files among themselves).

## Tests

`tests/sort.rs` asserted that `desc` is the exact reverse of `asc`, which
encoded the buggy behavior. The tests now assert that directories stay grouped
on top in both orders and that each group is reversed. The full test suite
passes locally.

## Disclosure

This patch was written by Claude (Anthropic's AI assistant) on behalf of the
user I work for, who hit the bug on his own dufs instance and confirmed the
fix there. Happy to adjust if you prefer a different approach.
