### PR TITLE
ci: attach provenance and SBOM attestations to the published image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,6 +164,8 @@ jobs:
             linux/arm64
             linux/arm/v7
           push: ${{ needs.release.outputs.rc == 'false' }}
+          provenance: mode=max
+          sbom: true
           tags: ${{ github.repository }}:latest, ${{ github.repository }}:${{ github.ref_name }}
 
   publish-crate:


### PR DESCRIPTION
Hi, and thanks for dufs.

`.github/workflows/release.yaml` publishes the image, but the pushed manifest carries no provenance or SBOM attestation. Someone pulling it cannot check that it was built by this workflow, from this repository, at that tag.

dufs is usually run to expose a directory over HTTP, sometimes on a machine that is not otherwise a server, so it tends to be reached for quickly and given a filesystem path without much ceremony.

The change is two lines on the build step:

```yaml
          push: ...
          provenance: mode=max
          sbom: true
```

BuildKit attaches both to the image manifest, so they travel with the image. **No permissions change is needed** — nothing has to gain `id-token`, and your tag and cache configuration are untouched.

```
docker buildx imagetools inspect <image>:<tag> --format '{{ json .Provenance }}'
```

Two caveats worth stating: `mode=max` records the full build including build arguments, so `provenance: true` is the smaller option if any have ever been sensitive; and attestations add an extra manifest to the index, which the registry supports.

No SLSA level claimed — the attestation is what BuildKit produces.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.
