### PR TITLE
fix: handle HEAD requests for internal routes

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -153,7 +153,7 @@ impl Server {
             }
         };
 
-        if method == Method::GET
+        if (method == Method::GET || method == Method::HEAD)
             && self
                 .handle_internal(&relative_path, headers, &mut res)
                 .await?

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -15,6 +15,14 @@ fn normal_health(server: TestServer) -> Result<(), Error> {
 }
 
 #[rstest]
+fn head_health(server: TestServer) -> Result<(), Error> {
+    let resp = fetch!(b"HEAD", format!("{}{HEALTH_CHECK_PATH}", server.url())).send()?;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text()?, "");
+    Ok(())
+}
+
+#[rstest]
 fn auth_health(
     #[with(&["--auth", "user:pass@/:rw", "-A"])] server: TestServer,
 ) -> Result<(), Error> {


### PR DESCRIPTION
HEAD is expected to return identical to GET minus the response body. (https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2-1). Non-internal routes already support HEAD, this change makes it consistent to the rest.