### PR TITLE
fix: clamp range last-pos to EOF per RFC 9110

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -106,8 +106,9 @@ pub fn parse_range(range: &str, size: u64) -> Option<Vec<(u64, u64)>> {
                     result.push((start, size - 1));
                 } else {
                     let end = end.parse::<u64>().ok()?;
-                    if end < size && start <= end {
-                        result.push((start, end));
+                    if start <= end {
+                        // RFC 9110 §14.1.2: clamp last-pos to size - 1
+                        result.push((start, end.min(size - 1)));
                     } else {
                         return None;
                     }
@@ -165,9 +166,19 @@ mod tests {
             parse_range("bytes=0-199, 100-399, 400-, -200", 500),
             Some(vec![(0, 199), (100, 399), (400, 499), (300, 499)])
         );
-        assert_eq!(parse_range("bytes=500-", 500), None);
+        // RFC 9110 §14.1.2: last-pos >= size is clamped to size - 1
+        assert_eq!(parse_range("bytes=0-500", 500), Some(vec![(0, 499)]));
+        assert_eq!(parse_range("bytes=0-999", 500), Some(vec![(0, 499)]));
+        assert_eq!(parse_range("bytes=300-999", 500), Some(vec![(300, 499)]));
+        assert_eq!(
+            parse_range("bytes=0-199, 300-999", 500),
+            Some(vec![(0, 199), (300, 499)])
+        );
+        // issue #735: 5-byte file
+        assert_eq!(parse_range("bytes=0-5", 5), Some(vec![(0, 4)]));
+        assert_eq!(parse_range("bytes=0-9", 5), Some(vec![(0, 4)]));
+        assert_eq!(parse_range("bytes=5-", 5), None);
         assert_eq!(parse_range("bytes=-501", 500), None);
-        assert_eq!(parse_range("bytes=0-500", 500), None);
         assert_eq!(parse_range("bytes=0-199,", 500), None);
         assert_eq!(parse_range("bytes=0-199, 500-", 500), None);
     }

--- a/tests/range.rs
+++ b/tests/range.rs
@@ -20,13 +20,18 @@ fn get_file_range(server: TestServer) -> Result<(), Error> {
 
 #[rstest]
 fn get_file_range_beyond(server: TestServer) -> Result<(), Error> {
+    // last-pos beyond EOF is clamped to size - 1 (RFC 9110 §14.1.2)
     let resp = fetch!(b"GET", format!("{}index.html", server.url()))
         .header("range", HeaderValue::from_static("bytes=12-20"))
         .send()?;
-    assert_eq!(resp.status(), 416);
-    assert_eq!(resp.headers().get("content-range").unwrap(), "bytes */18");
+    assert_eq!(resp.status(), 206);
+    assert_eq!(
+        resp.headers().get("content-range").unwrap(),
+        "bytes 12-17/18"
+    );
     assert_eq!(resp.headers().get("accept-ranges").unwrap(), "bytes");
-    assert_eq!(resp.headers().get("content-length").unwrap(), "0");
+    assert_eq!(resp.headers().get("content-length").unwrap(), "6");
+    assert_eq!(resp.text()?, "x.html");
     Ok(())
 }
 
@@ -37,6 +42,115 @@ fn get_file_range_invalid(server: TestServer) -> Result<(), Error> {
         .send()?;
     assert_eq!(resp.status(), 416);
     assert_eq!(resp.headers().get("content-range").unwrap(), "bytes */18");
+    Ok(())
+}
+
+#[rstest]
+fn get_file_range_last_pos_beyond_eof(server: TestServer) -> Result<(), Error> {
+    // RFC 9110 §14.1.2: last-pos >= size must be clamped to size - 1, not 416
+    let resp = fetch!(b"GET", format!("{}index.html", server.url()))
+        .header("range", HeaderValue::from_static("bytes=0-19"))
+        .send()?;
+    assert_eq!(resp.status(), 206);
+    assert_eq!(
+        resp.headers().get("content-range").unwrap(),
+        "bytes 0-17/18"
+    );
+    assert_eq!(resp.headers().get("accept-ranges").unwrap(), "bytes");
+    assert_eq!(resp.headers().get("content-length").unwrap(), "18");
+    assert_eq!(resp.text()?, "This is index.html");
+    Ok(())
+}
+
+#[rstest]
+fn get_file_range_last_pos_at_eof(server: TestServer) -> Result<(), Error> {
+    let resp = fetch!(b"GET", format!("{}index.html", server.url()))
+        .header("range", HeaderValue::from_static("bytes=0-18"))
+        .send()?;
+    assert_eq!(resp.status(), 206);
+    assert_eq!(
+        resp.headers().get("content-range").unwrap(),
+        "bytes 0-17/18"
+    );
+    assert_eq!(resp.headers().get("accept-ranges").unwrap(), "bytes");
+    assert_eq!(resp.headers().get("content-length").unwrap(), "18");
+    assert_eq!(resp.text()?, "This is index.html");
+    Ok(())
+}
+
+#[rstest]
+fn get_file_range_last_pos_beyond_eof_middle(server: TestServer) -> Result<(), Error> {
+    let resp = fetch!(b"GET", format!("{}index.html", server.url()))
+        .header("range", HeaderValue::from_static("bytes=6-99"))
+        .send()?;
+    assert_eq!(resp.status(), 206);
+    assert_eq!(
+        resp.headers().get("content-range").unwrap(),
+        "bytes 6-17/18"
+    );
+    assert_eq!(resp.headers().get("content-length").unwrap(), "12");
+    assert_eq!(resp.text()?, "s index.html");
+    Ok(())
+}
+
+#[rstest]
+fn head_file_range_last_pos_beyond_eof(server: TestServer) -> Result<(), Error> {
+    let resp = fetch!(b"HEAD", format!("{}index.html", server.url()))
+        .header("range", HeaderValue::from_static("bytes=0-19"))
+        .send()?;
+    assert_eq!(resp.status(), 206);
+    assert_eq!(
+        resp.headers().get("content-range").unwrap(),
+        "bytes 0-17/18"
+    );
+    assert_eq!(resp.headers().get("accept-ranges").unwrap(), "bytes");
+    assert_eq!(resp.headers().get("content-length").unwrap(), "18");
+    Ok(())
+}
+
+#[rstest]
+fn get_file_multipart_range_last_pos_beyond_eof(server: TestServer) -> Result<(), Error> {
+    let resp = fetch!(b"GET", format!("{}index.html", server.url()))
+        .header("range", HeaderValue::from_static("bytes=0-19, 6-17"))
+        .send()?;
+    assert_eq!(resp.status(), 206);
+    assert_eq!(resp.headers().get("accept-ranges").unwrap(), "bytes");
+
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()?
+        .to_string();
+    assert!(content_type.starts_with("multipart/byteranges; boundary="));
+
+    let boundary = content_type.split_once('=').unwrap().1.trim_ascii_start();
+    assert!(!boundary.is_empty());
+
+    let body = resp.text()?;
+    let parts = parse_multipart_body(&body, boundary);
+    assert_eq!(parts.len(), 2);
+
+    let (headers, body) = &parts[0];
+    assert_eq!(headers.get("content-range").unwrap(), "bytes 0-17/18");
+    assert_eq!(*body, "This is index.html");
+
+    let (headers, body) = &parts[1];
+    assert_eq!(headers.get("content-range").unwrap(), "bytes 6-17/18");
+    assert_eq!(*body, "s index.html");
+
+    Ok(())
+}
+
+#[rstest]
+fn get_file_multipart_range_first_pos_beyond_eof(server: TestServer) -> Result<(), Error> {
+    // Mixed satisfiable + unsatisfiable (first-pos >= size) is still 416
+    let resp = fetch!(b"GET", format!("{}index.html", server.url()))
+        .header("range", HeaderValue::from_static("bytes=0-19, 20-"))
+        .send()?;
+    assert_eq!(resp.status(), 416);
+    assert_eq!(resp.headers().get("content-range").unwrap(), "bytes */18");
+    assert_eq!(resp.headers().get("accept-ranges").unwrap(), "bytes");
     Ok(())
 }
 


### PR DESCRIPTION
## Problem

A `Range` header whose `last-pos` lies beyond the end of the file — e.g. `bytes=0-999` against a 500-byte file, or the exact-EOF case `bytes=0-5` against a 5-byte file (#735) — is answered `416 Range Not Satisfiable`, although the first part of the range is fully satisfiable.

RFC 9110 §14.1.2 requires the opposite: when `last-pos` is present and greater than or equal to the current length, the valid range is `first-pos .. length-1` and the server responds `206 Partial Content` with the clamped range. `416` is only for `first-pos >= length`.

## Root cause

`parse_range` in `src/utils.rs` rejected any range whose `end >= size` instead of clamping it:

```rust
if end < size && start <= end { /* satisfiable */ } else { return None; }
```

The `None` made `GET /file` (`src/server.rs`) set `416` + `Content-Range: bytes */{size}`.

## Fix

Clamp `end` to `size - 1` in `parse_range` (single and multipart ranges alike); `first-pos >= size` still returns unsatisfiable. The second caller, `parse_upload_offset` (WebDAV PATCH), only uses the start position and is unaffected.

## Tests

- Unit (`src/utils.rs`): 6 new assertions — exact EOF, beyond-EOF, mid-range beyond EOF, multipart with an out-of-range part, the two exact-EOF cases from the issue, and `first-pos == size` still unsatisfiable.
- Integration (`tests/range.rs`): 6 new tests against a real server — `206` with clamped `Content-Range` and the full body, the boundary `bytes=0-<len-1>`, mid-range clamping, `HEAD`, multipart where both parts are clamped, and mixed satisfiable + unsatisfiable parts still `416` (regression guard). The existing `get_file_range_beyond` expectation was corrected from `416` to the RFC-correct `206` `bytes 12-17/18`.

## Verification

- New unit tests fail on the old code and pass with the fix (red → green).
- `cargo test --all` — all 21 suites pass.
- `cargo clippy --all --all-targets` — no new warnings; `cargo fmt --all --check` clean.

Fixes #735
