### PR TITLE
fix: expand asset prefixes in custom 404 pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,9 @@ Your assets folder must contains a `index.html` file.
 - `__INDEX_DATA__`: directory listing data
 - `__ASSETS_PREFIX__`: assets url prefix
 
-> A customized 404.html page is also supported.
+> A customized `404.html` page is also supported. UTF-8 error pages can use
+> `__ASSETS_PREFIX__` for asset URLs, including the configured `--path-prefix`.
+> Unlike `index.html`, error pages do not receive `__INDEX_DATA__`.
 
 Here are some Third-party customize UI project:
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -344,7 +344,7 @@ impl Args {
         args.uri_prefix = if args.path_prefix.is_empty() {
             "/".to_owned()
         } else {
-            format!("/{}/", &encode_uri(&args.path_prefix))
+            format!("/{}/", encode_uri(&args.path_prefix))
         };
 
         if let Some(hidden) = matches.get_many::<String>("hidden") {

--- a/src/server.rs
+++ b/src/server.rs
@@ -79,7 +79,7 @@ impl Server {
                 args.uri_prefix[0..args.uri_prefix.len() - 1].to_string(),
                 encode_uri(&format!(
                     "{}{}",
-                    &args.uri_prefix,
+                    args.uri_prefix,
                     get_file_name(&args.serve_path)
                 )),
             ]
@@ -772,6 +772,13 @@ impl Server {
         Ok(())
     }
 
+    fn render_assets_prefix(&self, html: &str) -> String {
+        html.replace(
+            "__ASSETS_PREFIX__",
+            &format!("{}{}", self.args.uri_prefix, self.assets_prefix),
+        )
+    }
+
     async fn handle_not_found(
         &self,
         query_params: &HashMap<String, String>,
@@ -781,8 +788,25 @@ impl Server {
     ) -> Result<()> {
         if let Some(error_page) = &self.args.error_page {
             if !has_query_flag(query_params, "noscript") {
-                self.handle_send_file(error_page, headers, head_only, res)
-                    .await?;
+                let content = fs::read(error_page).await?;
+                if let Some(html) = std::str::from_utf8(&content)
+                    .ok()
+                    .filter(|html| html.contains("__ASSETS_PREFIX__"))
+                {
+                    let output = self.render_assets_prefix(html);
+                    res.headers_mut()
+                        .typed_insert(ContentType::from(mime_guess::mime::TEXT_HTML_UTF_8));
+                    res.headers_mut()
+                        .typed_insert(ContentLength(output.len() as u64));
+                    res.headers_mut()
+                        .typed_insert(CacheControl::new().with_no_cache());
+                    if !head_only {
+                        *res.body_mut() = body_full(output);
+                    }
+                } else {
+                    self.handle_send_file(error_page, headers, head_only, res)
+                        .await?;
+                }
                 *res.status_mut() = StatusCode::NOT_FOUND;
                 return Ok(());
             }
@@ -1036,11 +1060,7 @@ impl Server {
             .typed_insert(ContentType::from(mime_guess::mime::TEXT_HTML_UTF_8));
         let index_data = STANDARD.encode(serde_json::to_string(&data)?);
         let output = self
-            .html
-            .replace(
-                "__ASSETS_PREFIX__",
-                &format!("{}{}", self.args.uri_prefix, self.assets_prefix),
-            )
+            .render_assets_prefix(&self.html)
             .replace("__INDEX_DATA__", &index_data);
         res.headers_mut()
             .typed_insert(ContentLength(output.len() as u64));
@@ -1320,11 +1340,7 @@ impl Server {
                 .typed_insert(ContentType::from(mime_guess::mime::TEXT_HTML_UTF_8));
 
             let index_data = STANDARD.encode(serde_json::to_string(&data)?);
-            self.html
-                .replace(
-                    "__ASSETS_PREFIX__",
-                    &format!("{}{}", self.args.uri_prefix, self.assets_prefix),
-                )
+            self.render_assets_prefix(&self.html)
                 .replace("__INDEX_DATA__", &index_data)
         };
         res.headers_mut()
@@ -1585,7 +1601,7 @@ impl PathItem {
             LocalResult::Single(v) => format!("{}", v.format("%a, %d %b %Y %H:%M:%S GMT")),
             _ => String::new(),
         };
-        let mut href = encode_uri(&format!("{}{}", prefix, &self.name));
+        let mut href = encode_uri(&format!("{}{}", prefix, self.name));
         if self.is_dir() && !href.ends_with('/') {
             href.push('/');
         }

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -125,34 +125,76 @@ fn assets_override(tmpdir: TempDir, port: u16) -> Result<(), Error> {
 }
 
 #[rstest]
-fn assets_override_not_found_page(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let not_found_html = "<html><body>custom 404 page</body></html>";
+#[case("", true)]
+#[case("drive/nested", true)]
+#[case("", false)]
+fn assets_override_not_found_page(
+    tmpdir: TempDir,
+    port: u16,
+    #[case] prefix: &str,
+    #[case] has_placeholder: bool,
+) -> Result<(), Error> {
+    let template = "<html><head><link href=\"__ASSETS_PREFIX__favicon.ico\"></head><body>世界 <a href=\"__ASSETS_PREFIX__index.js\">asset</a></body></html>";
+    let not_found_html = if has_placeholder {
+        template
+    } else {
+        "<html><body>custom 404 page</body></html>"
+    };
     std::fs::write(
         tmpdir.join(format!("{}404.html", DIR_ASSETS)),
         not_found_html,
     )?;
 
-    let mut child = Command::new(assert_cmd::cargo::cargo_bin!())
+    std::fs::write(tmpdir.join(format!("{}favicon.ico", DIR_ASSETS)), b"icon")?;
+
+    let child = Command::new(assert_cmd::cargo::cargo_bin!())
         .arg(tmpdir.path())
         .arg("-p")
         .arg(port.to_string())
         .arg("--assets")
         .arg(tmpdir.join(DIR_ASSETS))
-        .stdout(Stdio::piped())
+        .arg("--path-prefix")
+        .arg(prefix)
+        .stdout(Stdio::null())
         .spawn()?;
-
+    let server = TestServer::new(port, tmpdir, child, false);
     wait_for_port(port);
 
-    let url = format!("http://localhost:{port}/missing-path");
-    let resp = reqwest::blocking::get(&url)?;
+    let uri_prefix = if prefix.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{prefix}/")
+    };
+    let assets_prefix = format!("{uri_prefix}__dufs_v{}__/", env!("CARGO_PKG_VERSION"));
+    let expected = not_found_html.replace("__ASSETS_PREFIX__", &assets_prefix);
+    let url = format!("http://localhost:{port}{uri_prefix}missing-path");
+    let client = reqwest::blocking::Client::new();
+    let resp = client.get(&url).send()?;
     assert_eq!(resp.status(), 404);
-    assert_eq!(resp.text()?, not_found_html);
+    assert_eq!(resp.headers()["content-length"], expected.len().to_string());
+    assert_eq!(
+        resp.headers()["content-type"]
+            .to_str()?
+            .to_ascii_lowercase(),
+        "text/html; charset=utf-8"
+    );
+    assert_eq!(resp.text()?, expected);
 
-    let url = format!("http://localhost:{port}/missing-path?noscript");
-    let resp = reqwest::blocking::get(&url)?;
+    let resp = client.head(&url).send()?;
+    assert_eq!(resp.status(), 404);
+    assert_eq!(resp.headers()["content-length"], expected.len().to_string());
+    assert!(resp.bytes()?.is_empty());
+
+    let resp = client.get(format!("{url}?noscript")).send()?;
     assert_eq!(resp.status(), 404);
     assert_eq!(resp.text()?, "Not Found");
 
-    child.kill()?;
+    // The same prefix must resolve to a real asset, not just look plausible in HTML.
+    let resp = client
+        .get(format!("http://localhost:{port}{assets_prefix}favicon.ico"))
+        .send()?;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.bytes()?.as_ref(), b"icon");
+    drop(server);
     Ok(())
 }


### PR DESCRIPTION
Custom `404.html` pages currently send `__ASSETS_PREFIX__` unchanged, so their asset URLs fail. This renders that placeholder with the configured path prefix, using the same helper as directory and editor pages. GET uses the rendered byte length; HEAD returns the same metadata without a body. Plain and non-UTF-8 error files retain the existing file-serving path, and `?noscript` keeps its plain response.

Refs #737. This addresses asset substitution; it does not rewrite a hard-coded `href="/"` or add index data to error pages.

Validation:
- Two real HTTP regressions failed before the fix (root and nested URL prefixes).
- `cargo test --all`: 190 passed, zero failed or ignored, including plain custom pages, GET/HEAD metadata, and retrieval through generated asset URLs.
- `cargo clippy --all --all-targets` with `RUSTFLAGS="--deny warnings"`: passed. Three existing redundant format borrows were also removed; their failures reproduced on untouched base `fe7fd564` under Rust 1.98 before those minimal corrections.
- `cargo fmt --all --check` and `git diff --check`: passed.

Validated locally on macOS; hosted Linux and Windows checks remain to run. Implemented and reviewed with Codex assistance.
