### PR TITLE
Refresh file actions after uploads complete

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -106,6 +106,8 @@ let $logoutBtn;
  */
 let $userName;
 
+let pathsRefreshVersion = 0;
+
 // manage unload event to prevent leaving with uploads in progress
 const beforeUnloadHandler = (event) => {
   if (Uploader.queues.length > 0 || Uploader.runnings > 0) {
@@ -272,14 +274,17 @@ class Uploader {
     this.lastUptime = now;
   }
 
-  complete() {
+  async complete() {
     const $uploadStatusNew = this.$uploadStatus.cloneNode(true);
     $uploadStatusNew.innerHTML = `✓`;
     this.$uploadStatus.parentNode.replaceChild($uploadStatusNew, this.$uploadStatus);
+    document.getElementById(`upload${this.idx}`).classList.add("upload-complete");
+    $emptyFolder.classList.add("hidden");
     this.$uploadStatus = null;
     failUploaders.delete(this.idx);
     Uploader.runnings--;
     Uploader.runQueue();
+    await refreshPaths();
   }
 
   fail(reason = "") {
@@ -448,6 +453,31 @@ function renderPathsTableBody() {
   }
 }
 
+async function refreshPaths() {
+  const version = ++pathsRefreshVersion;
+  const completedUploads = document.querySelectorAll(".upload-complete");
+  const url = new URL(location.href);
+  url.searchParams.set("json", "");
+  try {
+    const res = await fetch(url, { cache: "no-store" });
+    if (res.status !== 200) return;
+    const data = await res.json();
+    if (version !== pathsRefreshVersion || data.kind !== "Index" || !Array.isArray(data.paths)) return;
+    if (!data.paths.every(path => typeof path?.name === "string" && ["File", "Dir", "SymlinkFile", "SymlinkDir"].includes(path.path_type))) return;
+    DATA = data;
+    DIR_EMPTY_NOTE = PARAMS.q ? 'No results' : DATA.dir_exists ? 'Empty folder' : 'Folder will be created when a file is uploaded';
+    $pathsTableBody.innerHTML = "";
+    $pathsTable.classList.add("hidden");
+    $emptyFolder.classList.add("hidden");
+    renderPathsTableBody();
+    if (DATA.user) setupDownloadWithToken($pathsTableBody);
+    completedUploads.forEach(row => row.remove());
+    if (!$uploadersTable.querySelector(".uploader")) $uploadersTable.classList.add("hidden");
+  } catch {
+    // The upload succeeded; keep its completed row if the listing cannot be refreshed.
+  }
+}
+
 /**
  * Add pathitem
  * @param {PathItem} file
@@ -554,8 +584,8 @@ async function setupAuth() {
   }
 }
 
-function setupDownloadWithToken() {
-  document.querySelectorAll("a.dlwt").forEach(link => {
+function setupDownloadWithToken(root = document) {
+  root.querySelectorAll("a.dlwt").forEach(link => {
     link.addEventListener("click", async e => {
       e.preventDefault();
       try {
@@ -704,13 +734,15 @@ async function deletePath(index) {
   const file = DATA.paths[index];
   if (!file) return;
   await doDeletePath(file.name, newUrl(file.name), () => {
-    document.getElementById(`addPath${index}`)?.remove();
-    DATA.paths[index] = null;
+    const currentIndex = DATA.paths.findIndex(path => path?.name === file.name);
+    document.getElementById(`addPath${currentIndex}`)?.remove();
+    if (currentIndex !== -1) DATA.paths[currentIndex] = null;
     if (!DATA.paths.find(v => !!v)) {
       $pathsTable.classList.add("hidden");
       $emptyFolder.textContent = DIR_EMPTY_NOTE;
       $emptyFolder.classList.remove("hidden");
     }
+    refreshPaths();
   });
 }
 

--- a/tests/assets-upload.test.cjs
+++ b/tests/assets-upload.test.cjs
@@ -1,0 +1,210 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(path.join(__dirname, "../assets/index.js"), "utf8");
+const file = (name, size = 42) => ({ name, size, mtime: 1234567890000, path_type: "File" });
+
+function setup(paths = [], permissions = {}, search = "") {
+  const nodes = new Map();
+  function element(id, parent) {
+    const classes = new Set(["hidden"]);
+    if (/^upload\d+$/.test(id)) classes.add("uploader");
+    let html = "";
+    const node = {
+      id,
+      parent,
+      get innerHTML() { return html; },
+      set innerHTML(value) {
+        for (const child of [...nodes.values()]) if (child.parent === node) child.remove();
+        html = value;
+      },
+      classList: {
+        add: value => classes.add(value),
+        remove: value => classes.delete(value),
+        contains: value => classes.has(value),
+      },
+      addEventListener() {},
+      remove() {
+        for (const child of [...nodes.values()]) if (child.parent === node) child.remove();
+        nodes.delete(id);
+      },
+      cloneNode() { return { ...node }; },
+      parentNode: { replaceChild(replacement) { nodes.set(id, replacement); } },
+      insertAdjacentHTML(_position, value) {
+        html += value;
+        for (const match of value.matchAll(/id="([^"]+)"/g)) element(match[1], node);
+      },
+      querySelector(selector) {
+        return [...nodes.values()].find(value => value.parent === node && value.classList.contains(selector.slice(1)));
+      },
+    };
+    nodes.set(id, node);
+    return node;
+  }
+  const table = element("table"), body = element("body"), uploads = element("uploads"), empty = element("empty");
+  const initial = { kind: "Index", paths, dir_exists: true, allow_upload: true, allow_delete: true, ...permissions };
+  let response;
+  const requests = [];
+  const context = vm.createContext({
+    URLSearchParams, URL, console,
+    window: { location: { search }, addEventListener() {} },
+    location: { href: `http://localhost/prefix/sub/${search}` },
+    document: {
+      getElementById: id => nodes.get(id),
+      querySelectorAll: selector => [...nodes.values()].filter(value => value.classList.contains(selector.slice(1))),
+    },
+    fetch: async (url, options) => {
+      requests.push({ url: String(url), options });
+      return typeof response === "function" ? response() : response;
+    },
+    table, body, uploads, empty, initial,
+  });
+  const run = code => vm.runInContext(code, context);
+  run(source);
+  run(`
+    DATA = initial; DIR_EMPTY_NOTE = "Empty folder";
+    $pathsTable = table; $pathsTableBody = body; $uploadersTable = uploads; $emptyFolder = empty;
+    Uploader.runQueue = () => {};
+    var tokenRoots = [];
+    setupDownloadWithToken = root => tokenRoots.push(root.id);
+    renderPathsTableBody();
+  `);
+  const reply = values => { response = { status: 200, json: async () => ({ ...initial, paths: values }) }; };
+  reply(paths);
+  return {
+    nodes, table, body, uploads, empty, requests, run, reply,
+    get paths() { return run("DATA.paths"); },
+    respond(value) { response = value; },
+    upload(name) {
+      context.uploadFile = { name, size: 42 };
+      run("var current = new Uploader(uploadFile, []); current.upload(); Uploader.runnings = 1;");
+    },
+  };
+}
+
+test("successful uploads show server metadata and actions without reloading", async () => {
+  const state = setup();
+  state.upload("new.txt");
+  // The last existing file may have been deleted while this upload was running.
+  state.empty.classList.remove("hidden");
+  state.reply([file("new.txt", 99)]);
+  await state.run("current.complete()");
+  assert.equal(state.paths[0].size, 99);
+  assert.equal(state.paths[0].mtime, 1234567890000);
+  assert.equal(state.table.classList.contains("hidden"), false);
+  assert.equal(state.empty.classList.contains("hidden"), true);
+  assert.equal(state.nodes.has("upload0"), false);
+  assert.equal(state.uploads.classList.contains("hidden"), true);
+  for (const title of ["Edit file", "Move & Rename", "Delete", "Download file"])
+    assert.ok(state.body.innerHTML.includes(`title="${title}"`));
+});
+
+test("the server decides whether differently cased names are one file or two", async () => {
+  for (const names of [["existing.txt"], ["EXISTING.txt", "existing.txt"]]) {
+    const state = setup([file("existing.txt")]);
+    state.upload("EXISTING.txt");
+    state.reply(names.map(name => file(name)));
+    await state.run("current.complete()");
+    assert.deepEqual(state.paths.map(item => item.name), names);
+    assert.equal(state.nodes.has(`addPath${names.length}`), false);
+  }
+});
+
+for (const allow_upload of [false, true]) for (const allow_delete of [false, true]) {
+  test(`refreshed actions respect upload=${allow_upload}, delete=${allow_delete}`, async () => {
+    const state = setup([], { allow_upload, allow_delete });
+    state.upload("permissions.txt");
+    state.reply([file("permissions.txt")]);
+    await state.run("current.complete()");
+    assert.equal(state.body.innerHTML.includes('title="Delete"'), allow_delete);
+    for (const title of ["Edit file", "Move & Rename"])
+      assert.equal(state.body.innerHTML.includes(`title="${title}"`), allow_upload && allow_delete);
+    assert.equal(state.body.innerHTML.includes('title="View file"'), !(allow_upload && allow_delete));
+  });
+}
+
+test("refresh preserves search and sorting parameters, server ordering and URL encoding", async () => {
+  const state = setup([], {}, "?q=nested&sort=name&order=desc");
+  state.upload("new.txt");
+  state.reply([file("z.txt"), file("nested dir/a #&中.txt")]);
+  await state.run("current.complete()");
+  assert.equal(state.requests[0].url, "http://localhost/prefix/sub/?q=nested&sort=name&order=desc&json=");
+  assert.equal(state.requests[0].options.cache, "no-store");
+  assert.equal(state.paths[0].name, "z.txt");
+  assert.ok(state.body.innerHTML.includes("/prefix/sub/nested%20dir/a%20%23%26%E4%B8%AD.txt?edit"));
+  assert.match(state.body.innerHTML, /deletePath\(1\)/);
+});
+
+test("failed uploads retain retry controls without refreshing the listing", () => {
+  const state = setup();
+  state.upload("failed.txt");
+  state.run('current.fail("403 Forbidden")');
+  assert.equal(state.requests.length, 0);
+  assert.equal(state.nodes.has("upload0"), true);
+  assert.equal(state.nodes.has("addPath0"), false);
+  assert.match(state.nodes.get("uploadStatus0").innerHTML, /retry0/);
+  assert.equal(state.run("failUploaders.has(0)"), true);
+});
+
+for (const [name, response] of [
+  ["403", { status: 403 }],
+  ["invalid JSON", { status: 200, json: async () => { throw new SyntaxError("Invalid JSON"); } }],
+  ["invalid paths", { status: 200, json: async () => ({ kind: "Index", paths: [{}] }) }],
+  ["network failure", () => { throw new Error("Connection lost"); }],
+]) {
+  test(`a ${name} listing response preserves successful uploads and existing rows`, async () => {
+    const state = setup([file("existing.txt")]);
+    state.upload("new.txt");
+    state.respond(response);
+    await state.run("current.complete()");
+    assert.equal(state.paths.length, 1);
+    assert.equal(state.paths[0].name, "existing.txt");
+    assert.equal(state.nodes.has("addPath0"), true);
+    assert.equal(state.nodes.get("uploadStatus0").innerHTML, "✓");
+    assert.equal(state.run("failUploaders.has(0)"), false);
+    assert.equal(state.run("Uploader.runnings"), 0);
+  });
+}
+
+test("an older listing response cannot overwrite a newer refresh", async () => {
+  const state = setup();
+  let release;
+  state.respond(() => new Promise(resolve => { release = resolve; }));
+  const older = state.run("refreshPaths()");
+  state.reply([file("new.txt")]);
+  await state.run("refreshPaths()");
+  release({ status: 200, json: async () => ({ kind: "Index", paths: [file("old.txt")] }) });
+  await older;
+  assert.equal(state.paths[0].name, "new.txt");
+});
+
+test("refresh preserves pending upload rows and scopes download token setup", async () => {
+  const state = setup([], { user: "test-user" });
+  state.upload("first.txt");
+  state.run("var first = current;");
+  state.upload("second.txt");
+  state.reply([file("first.txt")]);
+  await state.run("first.complete()");
+  assert.equal(state.nodes.has("upload0"), false);
+  assert.equal(state.nodes.has("upload1"), true);
+  assert.equal(state.uploads.classList.contains("hidden"), false);
+  assert.equal(state.run("tokenRoots.join(',')"), "body");
+});
+
+test("a pending deletion removes its original file after the list is reordered", async () => {
+  const state = setup([file("a.txt"), file("b.txt"), file("c.txt")]);
+  state.run("var finishDelete; doDeletePath = async (name, url, callback) => { finishDelete = callback; };");
+  await state.run("deletePath(1)");
+  state.reply([file("c.txt"), file("a.txt"), file("b.txt")]);
+  await state.run("refreshPaths()");
+  state.respond({ status: 403 });
+  state.run("finishDelete()");
+  assert.deepEqual(state.paths.map(item => item?.name ?? null), ["c.txt", "a.txt", null]);
+  assert.equal(state.nodes.has("addPath0"), true);
+  assert.equal(state.nodes.has("addPath1"), true);
+  assert.equal(state.nodes.has("addPath2"), false);
+  assert.equal(state.requests.length, 2);
+});


### PR DESCRIPTION
Fixes #730.

After a successful upload, refresh the current directory listing from the server so permitted edit, rename, delete and download actions become available without reloading the page. Server metadata preserves canonical filename casing, ordering, search results and permissions. Pending and failed upload rows remain; a failed listing request retains the successful upload check mark.

Reject stale listing responses and refresh again after completed deletions. Resolve a pending deletion against its captured filename after list reordering, and scope authenticated download handlers to the replaced rows.

Validation: 15 dependency-free Node regressions (`node --test tests/assets-upload.test.cjs`), actual Chromium/Firefox uploads and controlled upload/delete/rename concurrency, case-only overwrite, permissions/authentication, encoded/nested paths, editing/downloads, and real partial-upload HEAD/PATCH retry. Source build and formatting pass; 185 Rust tests pass with two Windows symlink-privilege cases filtered. Those two failures reproduce on the base revision. Clippy reports three existing lints in unchanged Rust code, with complete diagnostic objects matching the independent base.

AI disclosure: implemented and tested by Codex/GPT-6. The final change also passed independent agent review; no human review is claimed.
