### PR TITLE
fix: normalize path segments to lowercase in ACL lookup and insert

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -267,7 +267,7 @@ impl AccessPaths {
             self.perm = perm;
             return;
         }
-        let child = self.children.entry(parts[0].to_string()).or_default();
+        let child = self.children.entry(parts[0].to_ascii_lowercase()).or_default();
         child.add_impl(&parts[1..], perm)
     }
 
@@ -327,7 +327,8 @@ impl AccessPaths {
                 return Some(AccessPaths::new(perm));
             }
         }
-        let child = match self.children.get(parts[0]) {
+        let key = parts[0].to_ascii_lowercase();
+        let child = match self.children.get(&key) {
             Some(v) => v,
             None => {
                 if perm.indexonly() {


### PR DESCRIPTION
Case-sensitive IndexMap lookups in find_impl/add_impl allow case-variant URIs to bypass per-path ACLs on case-insensitive filesystems (macOS APFS, Windows NTFS). Normalize segments with to_ascii_lowercase on both insert and lookup paths.
**I’ve also submitted a vulnerability report through the Security page with more detailed information about this issue. Please take a look when you have a chance, Thank you!**